### PR TITLE
⚡ Bolt: Add indexes to database tables

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - SQLite Database Indexes for Chat
+**Learning:** Found missing indexes for `SELECT * FROM conversations ORDER BY updated_at DESC` and `SELECT role, content, created_at FROM messages WHERE conversation_id = ? ORDER BY created_at`. In SQLite databases used for chat applications, these lookups happen constantly. A missing index on `conversation_id` in the `messages` table can cause full table scans every time a chat history is loaded.
+**Action:** Always add indexes for foreign keys (like `conversation_id`) and frequently sorted fields (like `updated_at` or `created_at`) when defining SQLite schema for chat history.

--- a/backend/db.py
+++ b/backend/db.py
@@ -31,6 +31,13 @@ def init_db():
             FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
         )
     """)
+
+    # ⚡ Bolt: Add indexes to speed up frequently executed queries
+    # Optimizes `SELECT * FROM conversations ORDER BY updated_at DESC`
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at DESC)")
+    # Optimizes `SELECT role, content, created_at FROM messages WHERE conversation_id = ? ORDER BY created_at`
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id, created_at)")
+
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
💡 **What:** Adds `CREATE INDEX IF NOT EXISTS` commands to `backend/db.py` to index the `conversation_id` and `created_at` fields in the `messages` table, and the `updated_at` field in the `conversations` table.

🎯 **Why:** To eliminate full table scans when fetching chat histories or displaying the recent conversations sidebar list. These queries happen constantly during normal app usage.

📊 **Impact:** Reduces lookup times for `messages` from O(N) (table scan) to O(log N) (B-tree index search), providing noticeably faster chat load times as conversations grow large.

🔬 **Measurement:** Execute an `EXPLAIN QUERY PLAN` on `SELECT role, content, created_at FROM messages WHERE conversation_id = 'test' ORDER BY created_at`. Without the index, SQLite does a full table scan. With the index, it uses the index directly without needing an extra sort step.

---
*PR created automatically by Jules for task [11131469340565394714](https://jules.google.com/task/11131469340565394714) started by @SamDeiter*