### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal bypass via `.startswith()`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Path Traversal bypass via `.startswith()`
+**Vulnerability:** In Python, verifying if a target path is inside a workspace using `str(target).startswith(str(workspace))` is vulnerable to directory traversal bypasses. For example, `/home/user/workspace_evil/file.txt` will pass the check against `/home/user/workspace` because it shares the same string prefix, even though it is in a different directory.
+**Learning:** `startswith()` only checks string prefixes and does not respect path boundaries or directory separators.
+**Prevention:** Use `os.path.commonpath([workspace, target]) == workspace` or `target.relative_to(workspace)` instead. These functions parse path segments properly and ensure the target is strictly a child directory or file of the workspace.

--- a/backend/routes/files.py
+++ b/backend/routes/files.py
@@ -47,8 +47,12 @@ async def list_files_api(path: str = "."):
     target = os.path.normpath(os.path.join(PROJECT_ROOT, path))
 
     # Security: prevent directory traversal (e.g., "../../etc/passwd")
-    if not target.startswith(PROJECT_ROOT):
+    try:
+        if os.path.commonpath([PROJECT_ROOT, target]) != os.path.normpath(PROJECT_ROOT):
+            return {"error": "Access denied", "files": []}
+    except ValueError:
         return {"error": "Access denied", "files": []}
+
     if not os.path.isdir(target):
         return {"error": "Not a directory", "files": []}
 
@@ -89,8 +93,12 @@ async def read_file_api(path: str):
     target = os.path.normpath(os.path.join(PROJECT_ROOT, path))
 
     # Security: prevent directory traversal
-    if not target.startswith(PROJECT_ROOT):
+    try:
+        if os.path.commonpath([PROJECT_ROOT, target]) != os.path.normpath(PROJECT_ROOT):
+            return {"error": "Access denied"}
+    except ValueError:
         return {"error": "Access denied"}
+
     if not os.path.isfile(target):
         return {"error": "File not found"}
 
@@ -123,7 +131,10 @@ async def write_file_api(request: Request):
     target = os.path.normpath(os.path.join(PROJECT_ROOT, path))
 
     # Security: prevent directory traversal
-    if not target.startswith(PROJECT_ROOT):
+    try:
+        if os.path.commonpath([PROJECT_ROOT, target]) != os.path.normpath(PROJECT_ROOT):
+            return {"error": "Access denied"}
+    except ValueError:
         return {"error": "Access denied"}
 
     try:

--- a/backend/tools/file_tools.py
+++ b/backend/tools/file_tools.py
@@ -23,13 +23,20 @@ def _validate_path(filepath: str) -> Path:
     target = (WORKSPACE / filepath).resolve()
 
     # Security: ensure the resolved path is still inside the workspace
-    if not str(target).startswith(str(WORKSPACE.resolve())):
+    try:
+        if os.path.commonpath([str(WORKSPACE.resolve()), str(target)]) != str(WORKSPACE.resolve()):
+            raise ValueError(f"Path escapes sandbox: {filepath}")
+    except ValueError:
+        # commonpath raises ValueError if paths are on different drives (Windows)
         raise ValueError(f"Path escapes sandbox: {filepath}")
 
     # Reject symlinks that point outside workspace
     if target.is_symlink():
         real = target.resolve()
-        if not str(real).startswith(str(WORKSPACE.resolve())):
+        try:
+            if os.path.commonpath([str(WORKSPACE.resolve()), str(real)]) != str(WORKSPACE.resolve()):
+                raise ValueError(f"Symlink escapes sandbox: {filepath}")
+        except ValueError:
             raise ValueError(f"Symlink escapes sandbox: {filepath}")
 
     return target


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** In Python, verifying if a target path is inside a workspace using `str(target).startswith(str(workspace))` is vulnerable to directory traversal bypasses. For example, `/home/user/workspace_evil/file.txt` will pass the check against `/home/user/workspace` because it shares the same string prefix, even though it is in a different directory.
**🎯 Impact:** A malicious user or agent execution could read, write or access unauthorized files on the system by crafting a path like `../LocalMind_Workspace_evil/file.py`.
**🔧 Fix:** Changed path verification to securely use `os.path.commonpath([workspace, target]) == workspace`. If this fails or raises a `ValueError`, access is securely denied.
**✅ Verification:** Verified tests and manual testing. See `.jules/sentinel.md` for journal learning.

---
*PR created automatically by Jules for task [12893326931131829203](https://jules.google.com/task/12893326931131829203) started by @SamDeiter*