### PR TITLE
🧪 Add tests for toggleMemoryList in sidebar.js

### DIFF
--- a/frontend/__tests__/sidebar.test.js
+++ b/frontend/__tests__/sidebar.test.js
@@ -1,0 +1,41 @@
+/**
+ * Tests for modules/sidebar.js
+ */
+
+import { toggleMemoryList } from "../modules/sidebar.js";
+
+describe("toggleMemoryList", () => {
+  beforeEach(() => {
+    // Clear the document body before each test
+    document.body.innerHTML = "";
+  });
+
+  test("toggles the 'open' class on memoryList element", () => {
+    // Arrange
+    document.body.innerHTML = '<div id="memoryList"></div>';
+    const list = document.getElementById("memoryList");
+    expect(list.classList.contains("open")).toBe(false);
+
+    // Act
+    toggleMemoryList();
+
+    // Assert
+    expect(list.classList.contains("open")).toBe(true);
+
+    // Act again
+    toggleMemoryList();
+
+    // Assert again
+    expect(list.classList.contains("open")).toBe(false);
+  });
+
+  test("does nothing and does not throw if memoryList element does not exist", () => {
+    // Arrange
+    expect(document.getElementById("memoryList")).toBeNull();
+
+    // Act & Assert
+    expect(() => {
+      toggleMemoryList();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing tests for `toggleMemoryList` in `frontend/modules/sidebar.js`.
📊 **Coverage:** The test coverage now includes the scenario where `toggleMemoryList` correctly toggles the `open` class on the `#memoryList` element, and the edge case where the `#memoryList` element doesn't exist, guaranteeing that the code doesn't throw.
✨ **Result:** Increased test coverage for DOM manipulation related to the sidebar. Test reliability is improved since Jest with JSDOM is perfectly suited for verifying that DOM nodes correctly receive CSS classes based on script invocations.

---
*PR created automatically by Jules for task [3472200607048424960](https://jules.google.com/task/3472200607048424960) started by @SamDeiter*