### PR TITLE
⚡ Bolt: Optimize count_active execution via mtime-aware caching

### DIFF
--- a/backend/proposals.py
+++ b/backend/proposals.py
@@ -8,6 +8,7 @@ Extracted from autonomy.py to keep files lean and editable.
 
 import json
 import logging
+import os
 import shutil
 import time
 import uuid
@@ -90,6 +91,8 @@ class ProposalManager:
 
     def __init__(self):
         self._failed_titles: set[str] = set()
+        self._active_count_cache = None
+        self._last_dir_mtime = None
         # Load failed titles from existing proposals on startup
         self._load_failed_titles()
 
@@ -323,6 +326,7 @@ class ProposalManager:
 
     def retry(self, proposal_id: str, emit_activity=None) -> Optional[dict]:
         """Reset a failed proposal to approved status for re-execution."""
+        self._invalidate_cache()
         if not PROPOSALS_DIR.exists():
             return None
 
@@ -387,8 +391,14 @@ class ProposalManager:
         self._failed_titles.add(proposal.get("title", ""))
         self._write_proposal(proposal)
 
+    def _invalidate_cache(self):
+        """Invalidate the active count cache."""
+        self._active_count_cache = None
+        self._last_dir_mtime = None
+
     def _write_proposal(self, proposal: dict):
         """Find a proposal's file on disk and update it."""
+        self._invalidate_cache()
         proposal_id = proposal.get("id")
         if not proposal_id or not PROPOSALS_DIR.exists():
             return
@@ -409,6 +419,19 @@ class ProposalManager:
         """Count proposals that are proposed or approved (i.e. still actionable)."""
         if not PROPOSALS_DIR.exists():
             return 0
+
+        try:
+            # Re-read dir stats
+            stat = os.stat(PROPOSALS_DIR)
+            current_mtime = stat.st_mtime
+        except OSError:
+            current_mtime = None
+
+        if (self._active_count_cache is not None
+            and getattr(self, "_last_dir_mtime", None) is not None
+            and current_mtime == self._last_dir_mtime):
+            return self._active_count_cache
+
         count = 0
         for f in PROPOSALS_DIR.glob("*.json"):
             try:
@@ -417,6 +440,9 @@ class ProposalManager:
                     count += 1
             except Exception:
                 continue
+
+        self._active_count_cache = count
+        self._last_dir_mtime = current_mtime
         return count
 
     def is_prerequisite_met(self, proposal: dict) -> bool:
@@ -457,6 +483,7 @@ class ProposalManager:
 
         Returns a summary: {archived: int, statuses: dict}.
         """
+        self._invalidate_cache()
         if not PROPOSALS_DIR.exists():
             return {"archived": 0, "statuses": {}}
 
@@ -492,6 +519,7 @@ class ProposalManager:
 
         Returns list of retried proposals.
         """
+        self._invalidate_cache()
         retried = []
         if not PROPOSALS_DIR.exists():
             return retried
@@ -523,6 +551,7 @@ class ProposalManager:
 
         Returns a summary of what was cleaned up.
         """
+        self._invalidate_cache()
         if not PROPOSALS_DIR.exists():
             return {"archived": 0, "deleted": 0}
 
@@ -572,6 +601,7 @@ class ProposalManager:
 
     def _update_status(self, proposal_id: str, new_status: str) -> Optional[dict]:
         """Update a proposal's status by ID."""
+        self._invalidate_cache()
         if not PROPOSALS_DIR.exists():
             return None
 

--- a/benchmark_count_active.py
+++ b/benchmark_count_active.py
@@ -1,0 +1,44 @@
+import time
+import os
+import shutil
+import json
+from pathlib import Path
+from backend.proposals import ProposalManager, PROPOSALS_DIR
+
+def setup_mock_proposals(num_proposals=1000):
+    if PROPOSALS_DIR.exists():
+        shutil.rmtree(PROPOSALS_DIR)
+    PROPOSALS_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"Creating {num_proposals} mock proposals...")
+    for i in range(num_proposals):
+        status = "proposed" if i % 2 == 0 else "completed"
+        proposal = {
+            "id": f"test_prop_{i}",
+            "title": f"Test Proposal {i}",
+            "status": status,
+            "created_at": time.time()
+        }
+        fp = PROPOSALS_DIR / f"test_prop_{i}_misc.json"
+        fp.write_text(json.dumps(proposal, indent=2), encoding="utf-8")
+    print("Done setting up mock proposals.")
+
+def benchmark_count_active(iterations=50):
+    manager = ProposalManager()
+
+    print(f"Benchmarking count_active over {iterations} iterations...")
+    start_time = time.time()
+    for _ in range(iterations):
+        manager.count_active()
+    end_time = time.time()
+
+    total_time = end_time - start_time
+    avg_time = total_time / iterations
+
+    print(f"Total time: {total_time:.4f}s")
+    print(f"Average time per call: {avg_time:.4f}s")
+    print(f"Result count: {manager.count_active()}")
+
+if __name__ == "__main__":
+    setup_mock_proposals(500)
+    benchmark_count_active(100)

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -1,0 +1,46 @@
+import os
+import json
+import time
+from pathlib import Path
+import pytest
+import backend.proposals as prop_mod
+from backend.proposals import ProposalManager
+
+@pytest.fixture
+def manager(tmp_path):
+    prop_mod.PROPOSALS_DIR = tmp_path / "proposals"
+    prop_mod.PROPOSALS_DIR.mkdir()
+    prop_mod.ARCHIVE_DIR = tmp_path / "archive"
+    return ProposalManager()
+
+def test_count_active(manager):
+    # Setup some files
+    for i in range(5):
+        status = "proposed" if i % 2 == 0 else "completed"
+        proposal = {
+            "id": f"test_prop_{i}",
+            "title": f"Test Proposal {i}",
+            "status": status,
+            "created_at": time.time()
+        }
+        fp = prop_mod.PROPOSALS_DIR / f"test_prop_{i}_misc.json"
+        fp.write_text(json.dumps(proposal, indent=2), encoding="utf-8")
+
+    assert manager.count_active() == 3 # 0, 2, 4 are proposed
+
+    # Test cache is working by not writing through manager
+    proposal = {
+        "id": f"test_prop_5",
+        "title": f"Test Proposal 5",
+        "status": "proposed",
+        "created_at": time.time()
+    }
+    fp = prop_mod.PROPOSALS_DIR / f"test_prop_5_misc.json"
+    fp.write_text(json.dumps(proposal, indent=2), encoding="utf-8")
+
+    # Mtime changes so cache invalidated
+    assert manager.count_active() == 4
+
+    # Update through manager, should invalidate cache
+    manager._update_status("test_prop_0", "completed")
+    assert manager.count_active() == 3


### PR DESCRIPTION
💡 **What:** Implemented a process-local caching mechanism for `ProposalManager.count_active()` in `backend/proposals.py`. The cache checks the `PROPOSALS_DIR`'s last modified time (`os.stat(PROPOSALS_DIR).st_mtime`) to detect new or deleted files, and uses manual invalidation hooks (`_invalidate_cache()`) in methods that mutate existing file contents.

🎯 **Why:** The dashboard polls the active proposal count frequently. As the number of proposals grows, calling `.glob("*.json")` and parsing every JSON file on disk becomes a CPU bottleneck, impacting overall backend performance. Caching the count reduces this from O(N) I/O to O(1) in-memory checks for most requests.

📊 **Measured Improvement:** A focused benchmark over 500 mock proposal files and 100 iterations showed a massive speedup:
- **Baseline:** ~0.0284s per call
- **Optimized:** ~0.0003s per call
- **Change:** ~99% reduction in execution time.

---
*PR created automatically by Jules for task [12045034127308229111](https://jules.google.com/task/12045034127308229111) started by @SamDeiter*