### PR TITLE
⚡ Bolt: non-blocking CPU usage monitoring

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-14 - SQLite Database Indexes for Chat
 **Learning:** Found missing indexes for `SELECT * FROM conversations ORDER BY updated_at DESC` and `SELECT role, content, created_at FROM messages WHERE conversation_id = ? ORDER BY created_at`. In SQLite databases used for chat applications, these lookups happen constantly. A missing index on `conversation_id` in the `messages` table can cause full table scans every time a chat history is loaded.
 **Action:** Always add indexes for foreign keys (like `conversation_id`) and frequently sorted fields (like `updated_at` or `created_at`) when defining SQLite schema for chat history.
+
+## 2025-05-15 - Non-blocking CPU Monitoring in FastAPI
+**Learning:** Using `psutil.cpu_percent(interval=0.1)` inside an async FastAPI route blocks the entire event loop for 100ms per request. This prevents the server from handling any other concurrent tasks (like chat streaming or autonomy loops) during that time.
+**Action:** Always use `psutil.cpu_percent(interval=None)` for non-blocking retrieval in async handlers. Ensure the measurement is "primed" by calling it once at the module level during startup.

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -9,6 +9,9 @@ from backend.config import OLLAMA_BASE_URL
 router = APIRouter(prefix="/api")
 logger = logging.getLogger("localmind.routes.system")
 
+# Initialize CPU measurement to avoid 0.0 on first call
+psutil.cpu_percent(interval=None)
+
 @router.get("/health")
 async def health_check():
     """Check server and Ollama connectivity."""
@@ -35,7 +38,9 @@ async def get_version():
 @router.get("/hardware")
 async def hardware_status():
     """Get system and Ollama hardware usage."""
-    cpu_pct = psutil.cpu_percent(interval=0.1)
+    # Using interval=None returns the average since the last call (non-blocking)
+    # This prevents blocking the event loop for 100ms.
+    cpu_pct = psutil.cpu_percent(interval=None)
     mem = psutil.virtual_memory()
     system = {
         "cpu_percent": cpu_pct,

--- a/tests/test_cpu_optimization.py
+++ b/tests/test_cpu_optimization.py
@@ -1,0 +1,20 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from backend.routes.system import hardware_status
+
+@pytest.mark.asyncio
+async def test_hardware_status_non_blocking_cpu():
+    """Verify that hardware_status calls psutil.cpu_percent with interval=None."""
+    with patch("psutil.cpu_percent") as mock_cpu:
+        mock_cpu.return_value = 5.0
+
+        # We also need to mock virtual_memory to avoid actual system calls
+        with patch("psutil.virtual_memory") as mock_mem:
+            mock_mem.return_value = MagicMock(used=8*1024**3, total=16*1024**3, percent=50.0)
+
+            # Execute the endpoint function
+            result = await hardware_status()
+
+            # Verify psutil.cpu_percent was called with interval=None
+            mock_cpu.assert_called_with(interval=None)
+            assert result["system"]["cpu_percent"] == 5.0


### PR DESCRIPTION
⚡ Bolt: non-blocking CPU usage monitoring

This change addresses a performance bottleneck where the `/api/hardware` endpoint was blocking the asynchronous event loop for 100ms on every request due to `psutil.cpu_percent(interval=0.1)`.

By switching to `interval=None`, the call becomes non-blocking, returning the average CPU usage since the last call. The measurement is primed at module load to avoid an initial 0.0 value.

A new unit test ensures that the optimization is maintained. 

Expected impact:
- `/api/hardware` latency reduced by ~99% (from >100ms to ~1ms).
- Improved overall server throughput and responsiveness, as the event loop is no longer hijacked by the CPU monitoring logic.

---
*PR created automatically by Jules for task [9842754869700445674](https://jules.google.com/task/9842754869700445674) started by @SamDeiter*