### PR TITLE
🎨 Palette: Enhance chat input accessibility and feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal - Critical UX/Accessibility Learnings
+
+## 2026-04-05 - Visual Feedback for Async Actions
+**Learning:** Users need immediate visual feedback when an action (like sending a message) is in progress, beyond just disabling the button. Adding `opacity-50` and `cursor-not-allowed` makes it clear that the interface is busy.
+**Action:** Always combine `disabled` state with visual classes like `opacity-50` and `cursor-not-allowed` for primary action buttons.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -466,9 +466,9 @@
                                     <span class="material-symbols-outlined text-[22px]">photo_camera</span>
                                 </button>
                             </div>
-                            <textarea id="messageInput" class="bg-transparent border-none focus:ring-0 text-md flex-1 placeholder:text-outline font-body resize-none overflow-y-auto min-h-[56px] py-4" placeholder="Transmit architectural directives or quick queries..." rows="1"></textarea>
+                            <textarea id="messageInput" aria-label="Chat message" title="Chat message" class="bg-transparent border-none focus:ring-0 text-md flex-1 placeholder:text-outline font-body resize-none overflow-y-auto min-h-[56px] py-4" placeholder="Transmit architectural directives or quick queries..." rows="1"></textarea>
                             <div class="flex items-center gap-1 pl-2">
-                                <button id="sendBtn" class="primary-gradient p-4 rounded-xl text-on-primary hover:brightness-110 transition-all h-full self-end shadow-lg shadow-primary/20">
+                                <button id="sendBtn" aria-label="Send message" title="Send message" class="primary-gradient p-4 rounded-xl text-on-primary hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-all h-full self-end shadow-lg shadow-primary/20">
                                     <span class="material-symbols-outlined text-[24px]">send</span>
                                 </button>
                             </div>


### PR DESCRIPTION
I have implemented a micro-UX enhancement for the chat interface in the LocalMind frontend.

Key changes:
- Updated `frontend/index.html` to add `aria-label` and `title` to `messageInput` and `sendBtn`.
- Added `disabled:opacity-50 disabled:cursor-not-allowed` to `sendBtn` in `frontend/index.html` for better visual feedback.
- Created `.jules/palette.md` to document the UX learning.

Verification:
- Ran `pnpm lint` and `pnpm test` successfully.
- Verified accessibility attributes and visual changes using a Playwright script and screenshots.
- Addressed code review feedback by refactoring to declarative Tailwind classes and ensuring the change is well under 50 lines.


---
*PR created automatically by Jules for task [13873613212172739288](https://jules.google.com/task/13873613212172739288) started by @SamDeiter*