### PR TITLE
🛡️ Sentinel: Fix secret exposure and remove dangerous eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,13 @@
 **Vulnerability:** In Python, verifying if a target path is inside a workspace using `str(target).startswith(str(workspace))` is vulnerable to directory traversal bypasses. For example, `/home/user/workspace_evil/file.txt` will pass the check against `/home/user/workspace` because it shares the same string prefix, even though it is in a different directory.
 **Learning:** `startswith()` only checks string prefixes and does not respect path boundaries or directory separators.
 **Prevention:** Use `os.path.commonpath([workspace, target]) == workspace` or `target.relative_to(workspace)` instead. These functions parse path segments properly and ensure the target is strictly a child directory or file of the workspace.
+
+## 2025-05-15 - State Corruption via In-Place Redaction
+**Vulnerability:** Redacting secrets in a dictionary returned by a shared utility (like `get_settings()`) without creating a copy modifies the underlying state. This replaces actual credentials with asterisks in the application's memory/cache, breaking features that rely on those secrets.
+**Learning:** Functions returning configuration often return references to shared objects. Direct mutation impacts the entire runtime.
+**Prevention:** Always use `.copy()` or `deepcopy()` before applying masks or redactions to data retrieved from shared modules.
+
+## 2025-05-15 - RCE/XSS via `eval()` on API Data
+**Vulnerability:** Calling `eval()` on a `code_snippet` field fetched from a backend API allows arbitrary JavaScript execution in the user's browser. If the backend or the communication channel is compromised, an attacker can execute malicious code.
+**Learning:** `eval()` is inherently dangerous and should never be used on data from external sources, even internal APIs.
+**Prevention:** Remove `eval()` usage. Display code using safe DOM APIs like `.textContent` and use syntax highlighters for visualization only. Never provide "Execute" functionality for arbitrary API-provided snippets.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -7,19 +7,34 @@ logger = logging.getLogger("localmind.routes.settings")
 
 @router.get("/settings/notifications")
 async def get_notification_settings():
-    """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    """Return current SMS/Text notification settings with secrets redacted."""
+    # Work on a copy to avoid corrupting shared state
+    settings = notifications.get_settings().copy()
+    for key in ["twilio_auth_token", "smtp_pass"]:
+        if settings.get(key):
+            val = settings[key]
+            settings[key] = "*" * (len(val) - 4) + val[-4:] if len(val) > 4 else "****"
+    return settings
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
-    """Update phone, carrier, and enable/disable status."""
-    notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    """Update phone, carrier, and enable/disable status, preserving masked secrets."""
+    incoming_settings = settings.copy()
+    current = notifications.get_settings()
+
+    # Handle masked fields for security sensitive keys
+    for key in ["twilio_auth_token", "smtp_pass"]:
+        if incoming_settings.get(key, "").startswith("****") and current.get(key):
+            incoming_settings[key] = current[key]
+
+    notifications.save_settings(incoming_settings)
+    return {"status": "ok", "settings": incoming_settings}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():
-    """Return current cloud configuration (Gemini)."""
-    settings = gemini_client.get_settings()
+    """Return current cloud configuration (Gemini) with secrets redacted."""
+    # Work on a copy to avoid corrupting shared state
+    settings = gemini_client.get_settings().copy()
     if settings.get("api_key"):
         key = settings["api_key"]
         settings["api_key"] = "*" * (len(key) - 4) + key[-4:] if len(key) > 4 else "****"
@@ -27,13 +42,13 @@ async def get_cloud_settings():
 
 @router.post("/settings/cloud")
 async def update_cloud_settings(settings: dict):
-    """Update Gemini API key."""
-    incoming_key = settings.get("api_key", "")
-    if incoming_key.startswith("****"):
+    """Update Gemini API key, preserving masked values."""
+    incoming_settings = settings.copy()
+    if incoming_settings.get("api_key", "").startswith("****"):
         current = gemini_client.get_settings()
         if current.get("api_key"):
-            settings["api_key"] = current["api_key"]
-    gemini_client.save_settings(settings)
+            incoming_settings["api_key"] = current["api_key"]
+    gemini_client.save_settings(incoming_settings)
     return {"status": "ok"}
 
 @router.post("/cloud/test")

--- a/frontend/modules/autonomy_ui.js
+++ b/frontend/modules/autonomy_ui.js
@@ -40,22 +40,6 @@ export async function pollAutonomy() {
       preElement.appendChild(codeElement);
       elements.codeSnippet.innerHTML = '';
       elements.codeSnippet.appendChild(preElement);
-
-      // Add a button to execute the code snippet
-const execButton = document.createElement('button');
-execButton.textContent = 'Execute';
-execButton.className = 'execute-code-btn';
-execButton.addEventListener('click', () => {
-try {
-eval(d.code_snippet);
-showToast('Code executed successfully!', 'info');
-} catch (error) {
-console.error('Error executing code:', error);
-showToast('Error executing code. Please check the console.', 'error');
-}
-});
-
-elements.codeSnippet.appendChild(execButton);
     }
 
     // Model is ready if health_check says so, OR if the engine is actively working

--- a/tests/test_settings_redaction.py
+++ b/tests/test_settings_redaction.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from backend.routes.settings import get_notification_settings, update_notification_settings, get_cloud_settings, update_cloud_settings
+
+@pytest.mark.asyncio
+async def test_notification_settings_redaction():
+    """Test that sensitive notification settings are redacted."""
+    mock_settings = {
+        "enabled": True,
+        "twilio_auth_token": "secret_token_123456789",
+        "smtp_pass": "my_secure_password",
+        "phone": "+1234567890"
+    }
+
+    with patch("backend.notifications.get_settings", return_value=mock_settings):
+        redacted = await get_notification_settings()
+        assert redacted["enabled"] is True
+        assert redacted["phone"] == "+1234567890"
+        assert redacted["twilio_auth_token"].startswith("****")
+        assert redacted["twilio_auth_token"].endswith("6789")
+        assert redacted["smtp_pass"].startswith("****")
+        assert redacted["smtp_pass"].endswith("word")
+
+@pytest.mark.asyncio
+async def test_notification_settings_masked_update():
+    """Test that masked notification settings do not overwrite existing secrets."""
+    current_settings = {
+        "enabled": True,
+        "twilio_auth_token": "original_token",
+        "smtp_pass": "original_pass"
+    }
+
+    incoming_settings = {
+        "enabled": False,
+        "twilio_auth_token": "********ken", # Masked
+        "smtp_pass": "new_pass" # Changed
+    }
+
+    with patch("backend.notifications.get_settings", return_value=current_settings):
+        with patch("backend.notifications.save_settings") as mock_save:
+            await update_notification_settings(incoming_settings)
+
+            # Should have preserved original token but updated pass
+            saved_data = mock_save.call_args[0][0]
+            assert saved_data["enabled"] is False
+            assert saved_data["twilio_auth_token"] == "original_token"
+            assert saved_data["smtp_pass"] == "new_pass"
+
+@pytest.mark.asyncio
+async def test_cloud_settings_redaction():
+    """Test that Gemini API key is redacted."""
+    mock_settings = {"api_key": "AIzaSy_test_key_12345"}
+
+    with patch("backend.gemini_client.get_settings", return_value=mock_settings):
+        redacted = await get_cloud_settings()
+        assert redacted["api_key"].startswith("****")
+        assert redacted["api_key"].endswith("2345")
+
+@pytest.mark.asyncio
+async def test_cloud_settings_masked_update():
+    """Test that masked cloud settings do not overwrite existing API key."""
+    current_settings = {"api_key": "original_api_key"}
+    incoming_settings = {"api_key": "********key"}
+
+    with patch("backend.gemini_client.get_settings", return_value=current_settings):
+        with patch("backend.gemini_client.save_settings") as mock_save:
+            await update_cloud_settings(incoming_settings)
+
+            saved_data = mock_save.call_args[0][0]
+            assert saved_data["api_key"] == "original_api_key"


### PR DESCRIPTION
### 🛡️ Sentinel Security Patch

**🚨 Severity: CRITICAL**

#### 💡 Vulnerability
1. **Plaintext Secret Exposure:** The settings endpoints returned sensitive credentials (`twilio_auth_token`, `smtp_pass`, `api_key`) in plaintext to the frontend.
2. **Remote Code Execution (RCE):** The frontend fetched a `code_snippet` from the autonomy status API and executed it via `eval()` when a button was clicked.

#### 🎯 Impact
- Attackers with access to the frontend could steal infrastructure secrets.
- Compromised backend data could lead to arbitrary JavaScript execution in the user's browser (RCE/XSS).

#### 🔧 Fix
- Implemented redaction in `backend/routes/settings.py` for both notification and cloud settings.
- **Crucial Bug Fix:** Used `.copy()` before redacting settings to prevent in-place corruption of the global application state.
- Removed the "Execute" button and the `eval()` call in `frontend/modules/autonomy_ui.js`.
- Added regression tests in `tests/test_settings_redaction.py`.

#### ✅ Verification
- **Backend:** `pytest tests/test_settings_redaction.py` (and existing tests) all passed.
- **Frontend:** `pnpm lint` and `pnpm test` passed. Verified removal of dangerous code via grep and Playwright script.
- **Sentinel Journal:** Updated `.jules/sentinel.md` with learnings.

---
*PR created automatically by Jules for task [12813273526612932439](https://jules.google.com/task/12813273526612932439) started by @SamDeiter*