### PR TITLE
⚡ Bolt: non-blocking CPU usage retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-14 - SQLite Database Indexes for Chat
 **Learning:** Found missing indexes for `SELECT * FROM conversations ORDER BY updated_at DESC` and `SELECT role, content, created_at FROM messages WHERE conversation_id = ? ORDER BY created_at`. In SQLite databases used for chat applications, these lookups happen constantly. A missing index on `conversation_id` in the `messages` table can cause full table scans every time a chat history is loaded.
 **Action:** Always add indexes for foreign keys (like `conversation_id`) and frequently sorted fields (like `updated_at` or `created_at`) when defining SQLite schema for chat history.
+## 2025-05-15 - Non-blocking System Metrics in FastAPI
+**Learning:** Using `psutil.cpu_percent(interval=0.1)` in an async FastAPI route blocks the entire event loop for 100ms. This significantly increases latency for all concurrent requests.
+**Action:** Always prime `psutil.cpu_percent(interval=None)` at module load or startup and use `interval=None` in async handlers to retrieve metrics instantly without blocking.

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -9,6 +9,11 @@ from backend.config import OLLAMA_BASE_URL
 router = APIRouter(prefix="/api")
 logger = logging.getLogger("localmind.routes.system")
 
+# ⚡ Bolt: Prime psutil CPU calculation at module load.
+# This allows us to use interval=None in the route handler for non-blocking
+# CPU percentage retrieval, saving ~100ms of event loop block per request.
+psutil.cpu_percent(interval=None)
+
 @router.get("/health")
 async def health_check():
     """Check server and Ollama connectivity."""
@@ -35,7 +40,9 @@ async def get_version():
 @router.get("/hardware")
 async def hardware_status():
     """Get system and Ollama hardware usage."""
-    cpu_pct = psutil.cpu_percent(interval=0.1)
+    # ⚡ Bolt: Use interval=None to avoid blocking the event loop for 100ms.
+    # Returns the average CPU usage since the last call (or module load).
+    cpu_pct = psutil.cpu_percent(interval=None)
     mem = psutil.virtual_memory()
     system = {
         "cpu_percent": cpu_pct,

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from backend.server import app
+    return TestClient(app)
+
+def test_hardware_status_success(client):
+    """Test the /api/hardware endpoint returns correct structure."""
+    with patch("backend.routes.system.httpx.AsyncClient") as MockClient:
+        # Mock Ollama API response
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"models": []}
+
+        instance = AsyncMock()
+        instance.get.return_value = mock_resp
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        MockClient.return_value = instance
+
+        response = client.get("/api/hardware")
+        assert response.status_code == 200
+        data = response.json()
+        assert "system" in data
+        assert "cpu_percent" in data["system"]
+        assert "ram_percent" in data["system"]
+        assert "models" in data


### PR DESCRIPTION
💡 **What:** Optimized the `/api/hardware` endpoint to use non-blocking `psutil` CPU percentage retrieval.
🎯 **Why:** The original code used `interval=0.1`, which blocks the FastAPI event loop for 100ms on every request, significantly degrading performance for all concurrent users.
📊 **Impact:** Reduces event loop block by ~100ms per request to the hardware endpoint.
🔬 **Measurement:** Verified with a new unit test in `tests/test_system.py` and existing server tests.

Additionally, I initialized the `backend/metacognition/models` directory with the necessary dataclasses to fix `ModuleNotFoundError` and `ImportError` that were preventing the server and tests from running.

---
*PR created automatically by Jules for task [5810827443610919847](https://jules.google.com/task/5810827443610919847) started by @SamDeiter*