### PR TITLE
🛡️ Sentinel: Fix terminal command injection bypass and hardcoded path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In Python, verifying if a target path is inside a workspace using `str(target).startswith(str(workspace))` is vulnerable to directory traversal bypasses. For example, `/home/user/workspace_evil/file.txt` will pass the check against `/home/user/workspace` because it shares the same string prefix, even though it is in a different directory.
 **Learning:** `startswith()` only checks string prefixes and does not respect path boundaries or directory separators.
 **Prevention:** Use `os.path.commonpath([workspace, target]) == workspace` or `target.relative_to(workspace)` instead. These functions parse path segments properly and ensure the target is strictly a child directory or file of the workspace.
+
+## 2024-05-25 - Terminal Command Injection Bypass via `.startswith()`
+**Vulnerability:** Using `command.startswith(dangerous_cmd)` to block shell commands is easily bypassed by adding leading whitespace or chaining commands (e.g., `ls; rm -rf /`).
+**Learning:** Shell command validation must account for shell operators (`;`, `&&`, `||`, `|`), newlines, and word boundaries to prevent bypasses and false positives.
+**Prevention:** Use regex with word boundaries and shell operator detection: `(?:^|[;&|]|\n)\s*\b(dangerous_cmd)\b`. Always trim input before validation.

--- a/backend/tools/terminal.py
+++ b/backend/tools/terminal.py
@@ -5,10 +5,12 @@ Provides safe shell execution with stderr/stdout capturing.
 
 import asyncio
 import subprocess
+import re
 from typing import Any
 import logging
 from .base import BaseTool
 from .propose_action import ProposeActionTool
+from backend.config import PROJECT_ROOT
 
 logger = logging.getLogger("localmind.tools.terminal")
 
@@ -38,11 +40,14 @@ class TerminalTool(BaseTool):
         }
 
     async def execute(self, **kwargs) -> dict[str, Any]:
-        command = kwargs.get("command")
+        command = kwargs.get("command", "").strip()
         timeout = kwargs.get("timeout", 10)
         
-        # Security check
-        is_dangerous = any(command.startswith(cmd) for cmd in DANGEROUS_COMMANDS)
+        # Security check: detect dangerous commands even if chained or preceded by whitespace
+        # Use regex to find dangerous commands at the start of the string or after shell separators
+        pattern = r"(?:^|[;&|]|\n)\s*\b(" + "|".join(re.escape(cmd) for cmd in DANGEROUS_COMMANDS) + r")\b"
+        is_dangerous = bool(re.search(pattern, command))
+
         if is_dangerous:
             proposer = ProposeActionTool()
             app_req = await proposer.execute(
@@ -60,7 +65,7 @@ class TerminalTool(BaseTool):
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=r"c:\Users\Sam Deiter\Documents\GitHub\LocalMind"
+                cwd=str(PROJECT_ROOT)
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             out = stdout.decode().strip()

--- a/tests/test_terminal_security.py
+++ b/tests/test_terminal_security.py
@@ -1,0 +1,33 @@
+
+import asyncio
+import pytest
+import re
+from backend.tools.terminal import TerminalTool, DANGEROUS_COMMANDS
+
+@pytest.mark.asyncio
+async def test_terminal_security_bypass_prevention():
+    # Test the regex pattern directly
+    pattern = r"(?:^|[;&|]|\n)\s*\b(" + "|".join(re.escape(cmd) for cmd in DANGEROUS_COMMANDS) + r")\b"
+
+    # Valid bypass attempts that should NOW be caught
+    assert bool(re.search(pattern, "  rm -rf /"))
+    assert bool(re.search(pattern, "ls; rm -rf /"))
+    assert bool(re.search(pattern, "ls && rm -rf /"))
+    assert bool(re.search(pattern, "ls || rm -rf /"))
+    assert bool(re.search(pattern, "echo hello\nrm -rf /"))
+    assert bool(re.search(pattern, "pip install requests"))
+
+    # Cases that should NOT be caught (legitimate commands containing substrings)
+    assert not bool(re.search(pattern, "echo rm"))
+    assert not bool(re.search(pattern, "format_disk")) # 'format' is dangerous but 'format_disk' is a different word
+    assert not bool(re.search(pattern, "ls -l"))
+
+@pytest.mark.asyncio
+async def test_terminal_cwd_is_project_root():
+    from backend.config import PROJECT_ROOT
+    tool = TerminalTool()
+    # Run 'pwd' on Linux or 'cd' on Windows to check current directory
+    # Since we are in a Linux-like environment in the sandbox:
+    result = await tool.execute(command="pwd")
+    if result["success"]:
+        assert result["stdout"].strip() == str(PROJECT_ROOT)


### PR DESCRIPTION
I have addressed a high-priority security issue in the `TerminalTool`. The original implementation used a weak `.startswith()` check for a blocklist of dangerous commands, which was easily bypassed by adding leading whitespace or chaining commands (e.g., `ls; rm`). Additionally, the tool contained a hardcoded absolute path from a developer's machine (`c:\Users\Sam Deiter\...`), which caused portability issues and leaked PII.

My fix:
1.  Implemented a robust regular expression for command validation that handles whitespace, shell operators (`;`, `&&`, `||`, `|`), and word boundaries.
2.  Ensured the input command is trimmed before validation.
3.  Replaced the hardcoded `cwd` with the application's `PROJECT_ROOT`.
4.  Created a new test suite `tests/test_terminal_security.py` to verify the security fixes and the correct working directory.
5.  All tests pass, and the change is under 50 lines.

---
*PR created automatically by Jules for task [1383599488760805378](https://jules.google.com/task/1383599488760805378) started by @SamDeiter*