### PR TITLE
🛡️ Sentinel: Mask sensitive settings credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-03-05 - Credential Exposure in Settings API
+**Vulnerability:** Sensitive fields like `smtp_pass` and `api_key` were returned in plain text in API responses from `/api/settings/*`, exposing them to anyone with access to the frontend or network logs.
+**Learning:** Returning full configuration objects directly to the frontend without a filtering/masking layer is a common source of credential leaks. Additionally, masking on retrieval requires "preservation" logic on updates to avoid overwriting real secrets with mask placeholders.
+**Prevention:** Always use `.copy()` when retrieving shared configuration objects to avoid mutating the global state. Apply masking to sensitive fields before returning them. In update handlers, detect the mask placeholder (e.g., `****`) and restore the original secret from storage if the placeholder is received.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -7,19 +7,32 @@ logger = logging.getLogger("localmind.routes.settings")
 
 @router.get("/settings/notifications")
 async def get_notification_settings():
-    """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    """Return current SMS/Text notification settings with masked password."""
+    settings = notifications.get_settings().copy()
+    if settings.get("smtp_pass"):
+        # Mask the SMTP password
+        settings["smtp_pass"] = "****"
+    return settings
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
-    """Update phone, carrier, and enable/disable status."""
+    """Update phone, carrier, and enable/disable status. Preserves and masks password."""
+    incoming_pass = settings.get("smtp_pass", "")
+    if incoming_pass == "****":
+        current = notifications.get_settings()
+        if current.get("smtp_pass"):
+            settings["smtp_pass"] = current["smtp_pass"]
     notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    # Mask password in the response to avoid leaking it back
+    response_settings = settings.copy()
+    if response_settings.get("smtp_pass"):
+        response_settings["smtp_pass"] = "****"
+    return {"status": "ok", "settings": response_settings}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():
-    """Return current cloud configuration (Gemini)."""
-    settings = gemini_client.get_settings()
+    """Return current cloud configuration (Gemini) with masked API key."""
+    settings = gemini_client.get_settings().copy()
     if settings.get("api_key"):
         key = settings["api_key"]
         settings["api_key"] = "*" * (len(key) - 4) + key[-4:] if len(key) > 4 else "****"

--- a/tests/test_settings_masking.py
+++ b/tests/test_settings_masking.py
@@ -1,0 +1,52 @@
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+from backend.routes.settings import get_notification_settings, update_notification_settings, get_cloud_settings
+
+@pytest.mark.asyncio
+async def test_get_notification_settings_masking():
+    mock_settings = {"smtp_pass": "secret123", "other": "data"}
+    with patch("backend.notifications.get_settings", return_value=mock_settings):
+        result = await get_notification_settings()
+        assert result["smtp_pass"] == "****"
+        assert result["other"] == "data"
+        assert mock_settings["smtp_pass"] == "secret123"
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_preservation():
+    mock_settings = {"smtp_pass": "secret123", "other": "old"}
+    new_settings = {"smtp_pass": "****", "other": "new"}
+
+    with patch("backend.notifications.get_settings", return_value=mock_settings), \
+         patch("backend.notifications.save_settings") as mock_save:
+        result = await update_notification_settings(new_settings)
+        mock_save.assert_called_once()
+        saved_data = mock_save.call_args[0][0]
+        assert saved_data["smtp_pass"] == "secret123"
+        assert saved_data["other"] == "new"
+        # Verify response masking
+        assert result["settings"]["smtp_pass"] == "****"
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_change():
+    mock_settings = {"smtp_pass": "secret123", "other": "old"}
+    new_settings = {"smtp_pass": "newsecret", "other": "new"}
+
+    with patch("backend.notifications.get_settings", return_value=mock_settings), \
+         patch("backend.notifications.save_settings") as mock_save:
+        result = await update_notification_settings(new_settings)
+        mock_save.assert_called_once()
+        saved_data = mock_save.call_args[0][0]
+        assert saved_data["smtp_pass"] == "newsecret"
+        assert saved_data["other"] == "new"
+        # Verify response masking
+        assert result["settings"]["smtp_pass"] == "****"
+
+@pytest.mark.asyncio
+async def test_get_cloud_settings_masking():
+    mock_settings = {"api_key": "AIzaSyTest1234567890"}
+    with patch("backend.gemini_client.get_settings", return_value=mock_settings):
+        result = await get_cloud_settings()
+        assert result["api_key"].startswith("****")
+        assert result["api_key"].endswith("7890")
+        assert mock_settings["api_key"] == "AIzaSyTest1234567890"


### PR DESCRIPTION
Masked sensitive credentials (SMTP passwords and API keys) in API responses to prevent exposure. Added preservation logic to allow updates while keeping secrets hidden. Verified with new unit tests and updated the security journal.

---
*PR created automatically by Jules for task [7353790895927975684](https://jules.google.com/task/7353790895927975684) started by @SamDeiter*