### PR TITLE
🛡️ Sentinel: Secure masking of notification credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,13 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-06-25 - In-place mutation of shared settings
+**Vulnerability:** Directly modifying settings dictionaries returned by a retrieval function (e.g., ) can corrupt the in-memory state of the application. If secrets are masked in-place for a GET request, subsequent operations (like background jobs or POST updates) may use the masked values, leading to authentication failures or permanent data loss if the masked values are saved back to disk.
+**Learning:** Python dictionaries are passed by reference. Mutating a configuration object in a route handler affects all other modules sharing that reference.
+**Prevention:** Always use `.copy()` or create a new dictionary when modifying sensitive data for presentation (masking/redaction). Centralize masking logic in helper functions that guarantee a fresh, non-mutated copy is returned.
+
+## 2024-06-25 - In-place mutation of shared settings
+**Vulnerability:** Directly modifying settings dictionaries returned by a retrieval function (e.g., `notifications.get_settings()`) can corrupt the in-memory state of the application. If secrets are masked in-place for a GET request, subsequent operations (like background jobs or POST updates) may use the masked values, leading to authentication failures or permanent data loss if the masked values are saved back to disk.
+**Learning:** Python dictionaries are passed by reference. Mutating a configuration object in a route handler affects all other modules sharing that reference.
+**Prevention:** Always use `.copy()` or create a new dictionary when modifying sensitive data for presentation (masking/redaction). Centralize masking logic in helper functions that guarantee a fresh, non-mutated copy is returned.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -122,16 +122,35 @@ async def get_user_profile(user_id: str = "default"):
         return {"status": "ok", "profile": profile}
     return {"status": "not_found", "profile": None}
 
+def _mask_settings(settings: dict) -> dict:
+    """Mask sensitive fields in a copy of the settings dictionary."""
+    masked = settings.copy()
+    for field in ["smtp_pass", "twilio_auth_token"]:
+        if masked.get(field):
+            val = masked[field]
+            masked[field] = "*" * (len(val) - 4) + val[-4:] if len(val) > 4 else "****"
+    return masked
+
+
 @router.get("/settings/notifications")
 async def get_notification_settings():
     """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    settings = notifications.get_settings()
+    return _mask_settings(settings)
+
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
     """Update phone, carrier, and enable/disable status."""
+    current = notifications.get_settings()
+    # If placeholder is sent, restore the existing secret
+    for field in ["smtp_pass", "twilio_auth_token"]:
+        incoming_val = settings.get(field, "")
+        if incoming_val.startswith("****") and current.get(field):
+            settings[field] = current[field]
+
     notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    return {"status": "ok", "settings": _mask_settings(settings)}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():

--- a/tests/test_settings_masking.py
+++ b/tests/test_settings_masking.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from backend.routes.settings import get_notification_settings, update_notification_settings
+
+@pytest.mark.asyncio
+async def test_get_notification_settings_masking():
+    # Mock settings with secrets
+    mock_settings = {
+        "enabled": True,
+        "smtp_pass": "super-secret-password",
+        "twilio_auth_token": "long-twilio-token-12345",
+        "phone": "1234567890"
+    }
+
+    with patch("backend.notifications.get_settings", return_value=mock_settings):
+        response = await get_notification_settings()
+
+        # Verify secrets are masked but other fields are preserved
+        assert response["enabled"] is True
+        assert response["phone"] == "1234567890"
+        # "super-secret-password" is 21 chars. Mask = 17 * '*' + 'word'
+        assert response["smtp_pass"] == "*" * 17 + "word"
+        # "long-twilio-token-12345" is 23 chars. Mask = 19 * '*' + '2345'
+        assert response["twilio_auth_token"] == "*" * 19 + "2345"
+
+        # IMPORTANT: Verify original mock_settings was NOT mutated
+        assert mock_settings["smtp_pass"] == "super-secret-password"
+        assert mock_settings["twilio_auth_token"] == "long-twilio-token-12345"
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_preservation():
+    # Existing settings with secrets
+    current_settings = {
+        "enabled": True,
+        "smtp_pass": "original-secret",
+        "twilio_auth_token": "original-token"
+    }
+
+    # Incoming settings from frontend with placeholders
+    incoming_settings = {
+        "enabled": False,
+        "smtp_pass": "****",
+        "twilio_auth_token": "********token", # also starts with ****
+        "phone": "9999999999"
+    }
+
+    with patch("backend.notifications.get_settings", return_value=current_settings), \
+         patch("backend.notifications.save_settings") as mock_save:
+
+        response = await update_notification_settings(incoming_settings)
+
+        # Verify save_settings was called with the ORIGINAL secrets restored
+        saved_data = mock_save.call_args[0][0]
+        assert saved_data["smtp_pass"] == "original-secret"
+        assert saved_data["twilio_auth_token"] == "original-token"
+        assert saved_data["enabled"] is False
+        assert saved_data["phone"] == "9999999999"
+
+        # Verify response is masked
+        assert response["status"] == "ok"
+        # "original-secret" (15 chars) -> 11 * '*' + 'cret'
+        assert response["settings"]["smtp_pass"] == "*" * 11 + "cret"
+        # "original-token" (14 chars) -> 10 * '*' + 'oken'
+        assert response["settings"]["twilio_auth_token"] == "*" * 10 + "oken"
+
+        # Verify original incoming_settings was NOT mutated (it was restored, but saved_data is what matters)
+        # Actually update_notification_settings(settings) DOES mutate the input 'settings' dict by design
+        # to restore secrets before saving. This is generally acceptable for a POST body dict.
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_new_values():
+    current_settings = {
+        "smtp_pass": "old-pass",
+    }
+    incoming_settings = {
+        "smtp_pass": "new-pass-123456",
+    }
+
+    with patch("backend.notifications.get_settings", return_value=current_settings), \
+         patch("backend.notifications.save_settings") as mock_save:
+
+        await update_notification_settings(incoming_settings)
+
+        saved_data = mock_save.call_args[0][0]
+        assert saved_data["smtp_pass"] == "new-pass-123456"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Sensitive notification credentials (`smtp_pass`, `twilio_auth_token`) were exposed in plaintext via the settings API.
🎯 Impact: Secrets could be leaked to the frontend or captured in logs/proxies.
🔧 Fix: Implemented secure masking using a non-mutating helper function. Added restoration logic to preserve existing secrets during updates when a placeholder is received.
✅ Verification: Created `tests/test_settings_masking.py` to verify masking on GET and durable preservation on POST. Verified original objects remain unmasked.

---
*PR created automatically by Jules for task [12976338505665453940](https://jules.google.com/task/12976338505665453940) started by @SamDeiter*