### PR TITLE
🛡️ Sentinel: mask sensitive notification and cloud settings

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - Sensitive Credential Exposure in Settings API
+**Vulnerability:** API endpoints that return configuration settings (like SMTP passwords or API keys) for user review in the UI will leak these secrets in plaintext unless explicitly masked. Partial masking (e.g., revealing last 4 characters) still leaks information like secret length and character patterns.
+**Learning:** Returning secrets in any form to the UI increases the attack surface. Furthermore, updating settings requires a preservation mechanism so the UI doesn't overwrite a secret with a placeholder.
+**Prevention:** Implement a centralized masking helper that replaces sensitive values with a static placeholder (e.g., `****`). Implement "preservation logic" in POST/PUT handlers: if the incoming value is the placeholder, restore the actual secret from storage before saving.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -36,6 +36,21 @@ def _save_plaintext_profile(user_id: str, profile: dict) -> None:
     _PROFILE_JSON_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+def _mask_settings(settings: dict) -> dict:
+    """Return a copy of *settings* with sensitive fields masked."""
+    if not settings:
+        return {}
+
+    masked = settings.copy()
+    sensitive_keys = {"api_key", "smtp_pass", "twilio_auth_token", "twilio_sid"}
+
+    for key in sensitive_keys:
+        if masked.get(key):
+            # Mask everything but show it's a placeholder
+            masked[key] = "****"
+    return masked
+
+
 def _load_profile(user_id: str, enc) -> dict | None:
     """Load a user profile, decrypting if necessary."""
     # Try encrypted first
@@ -125,31 +140,32 @@ async def get_user_profile(user_id: str = "default"):
 @router.get("/settings/notifications")
 async def get_notification_settings():
     """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    return _mask_settings(notifications.get_settings())
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
     """Update phone, carrier, and enable/disable status."""
+    # Restore masked fields from current storage
+    current = notifications.get_settings()
+    for key in ["smtp_pass", "twilio_auth_token", "twilio_sid"]:
+        if settings.get(key) == "****":
+            settings[key] = current.get(key)
+
     notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    return {"status": "ok", "settings": _mask_settings(settings)}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():
     """Return current cloud configuration (Gemini)."""
-    settings = gemini_client.get_settings()
-    if settings.get("api_key"):
-        key = settings["api_key"]
-        settings["api_key"] = "*" * (len(key) - 4) + key[-4:] if len(key) > 4 else "****"
-    return settings
+    return _mask_settings(gemini_client.get_settings())
 
 @router.post("/settings/cloud")
 async def update_cloud_settings(settings: dict):
     """Update Gemini API key."""
-    incoming_key = settings.get("api_key", "")
-    if incoming_key.startswith("****"):
+    if settings.get("api_key") == "****":
         current = gemini_client.get_settings()
-        if current.get("api_key"):
-            settings["api_key"] = current["api_key"]
+        settings["api_key"] = current.get("api_key")
+
     gemini_client.save_settings(settings)
     return {"status": "ok"}
 

--- a/tests/test_settings_masking.py
+++ b/tests/test_settings_masking.py
@@ -1,0 +1,78 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from backend.server import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_auth():
+    with patch("backend.security.auth.authenticate_request") as mock_auth:
+        mock_auth.return_value = {"user_id": "test_user", "role": "admin", "key_id": "test_key"}
+        yield mock_auth
+
+@pytest.fixture
+def mock_rbac():
+    with patch("backend.security.rbac.check_permission") as mock_rbac:
+        yield mock_rbac
+
+def test_notification_settings_masked(mock_auth, mock_rbac):
+    """Verify that sensitive notification settings are masked."""
+    test_settings = {
+        "enabled": True,
+        "method": "email-to-sms",
+        "phone": "1234567890",
+        "carrier": "verizon",
+        "smtp_user": "user@example.com",
+        "smtp_pass": "supersecretpassword",
+        "twilio_sid": "AC12345",
+        "twilio_auth_token": "secret_token"
+    }
+
+    with patch("backend.notifications.get_settings", return_value=test_settings):
+        response = client.get("/api/settings/notifications")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["smtp_pass"] == "****"
+        assert data["twilio_auth_token"] == "****"
+        assert data["twilio_sid"] == "****"
+        assert data["phone"] == "1234567890"  # Non-sensitive preserved
+
+def test_cloud_settings_masked(mock_auth, mock_rbac):
+    """Verify that cloud settings (Gemini API key) are fully masked."""
+    test_settings = {
+        "api_key": "AIzaSy_ActualKey12345"
+    }
+
+    with patch("backend.gemini_client.get_settings", return_value=test_settings):
+        response = client.get("/api/settings/cloud")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["api_key"] == "****"
+
+def test_notification_settings_preservation(mock_auth, mock_rbac):
+    """Verify that masked placeholders are preserved during update."""
+    current_settings = {
+        "enabled": True,
+        "smtp_pass": "original_secret",
+        "phone": "1234567890"
+    }
+
+    incoming_settings = {
+        "enabled": True,
+        "smtp_pass": "****",  # Masked placeholder
+        "phone": "0987654321" # Updated non-sensitive field
+    }
+
+    with patch("backend.notifications.get_settings", return_value=current_settings), \
+         patch("backend.notifications.save_settings") as mock_save:
+
+        response = client.post("/api/settings/notifications", json=incoming_settings)
+        assert response.status_code == 200
+
+        # Verify that original_secret was restored
+        saved_args = mock_save.call_args[0][0]
+        assert saved_args["smtp_pass"] == "original_secret"
+        assert saved_args["phone"] == "0987654321"


### PR DESCRIPTION
This PR fixes a security vulnerability where sensitive credentials (SMTP passwords, Twilio auth tokens, Gemini API keys) were being leaked in plaintext or partially masked through the settings API. 

The fix introduces a static `****` mask for all sensitive fields in GET responses and a preservation mechanism in POST handlers that restores the original secret from storage if the placeholder is received from the UI. This prevents both information leakage and accidental overwriting of credentials.

---
*PR created automatically by Jules for task [15981183501959899756](https://jules.google.com/task/15981183501959899756) started by @SamDeiter*