### PR TITLE
🛡️ Sentinel: mask sensitive settings and enhance prompt guard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-05-24 - Masking Sensitive Settings with Preservation
+**Vulnerability:** Exposing raw credentials (API keys, SMTP passwords) in GET responses to the frontend increases the risk of credential theft via XSS or shoulder surfing.
+**Learning:** Simply masking the output is insufficient if the user needs to update OTHER settings in the same form without re-entering the secret. The backend must recognize a placeholder (e.g., `****`) and preserve the existing secret.
+**Prevention:** Use a centralized `_mask_settings` helper for all configuration GET routes and a `_preserve_secrets` helper for POST routes. This ensures secrets are redacted in transit to the UI but maintained in storage unless explicitly changed by the user.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -60,6 +60,30 @@ def _load_profile(user_id: str, enc) -> dict | None:
     return None
 
 
+# ── Settings Masking & Preservation ───────────────────────────────────
+
+def _mask_settings(settings: dict) -> dict:
+    """Mask sensitive fields in settings with '****'."""
+    masked = settings.copy()
+    sensitive_fields = ["api_key", "smtp_pass", "twilio_auth_token"]
+    for field in sensitive_fields:
+        if masked.get(field):
+            masked[field] = "****"
+    return masked
+
+
+def _preserve_secrets(incoming: dict, existing: dict) -> dict:
+    """Preserve existing secrets if incoming values are masked."""
+    updated = incoming.copy()
+    sensitive_fields = ["api_key", "smtp_pass", "twilio_auth_token"]
+    for field in sensitive_fields:
+        incoming_val = updated.get(field, "")
+        if isinstance(incoming_val, str) and incoming_val.startswith("****"):
+            if existing.get(field):
+                updated[field] = existing[field]
+    return updated
+
+
 # ── User-profile endpoints ───────────────────────────────────────────
 
 @router.post("/user-profile")
@@ -125,32 +149,29 @@ async def get_user_profile(user_id: str = "default"):
 @router.get("/settings/notifications")
 async def get_notification_settings():
     """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    settings = notifications.get_settings()
+    return _mask_settings(settings)
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
     """Update phone, carrier, and enable/disable status."""
-    notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    existing = notifications.get_settings()
+    updated = _preserve_secrets(settings, existing)
+    notifications.save_settings(updated)
+    return {"status": "ok", "settings": _mask_settings(updated)}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():
     """Return current cloud configuration (Gemini)."""
     settings = gemini_client.get_settings()
-    if settings.get("api_key"):
-        key = settings["api_key"]
-        settings["api_key"] = "*" * (len(key) - 4) + key[-4:] if len(key) > 4 else "****"
-    return settings
+    return _mask_settings(settings)
 
 @router.post("/settings/cloud")
 async def update_cloud_settings(settings: dict):
     """Update Gemini API key."""
-    incoming_key = settings.get("api_key", "")
-    if incoming_key.startswith("****"):
-        current = gemini_client.get_settings()
-        if current.get("api_key"):
-            settings["api_key"] = current["api_key"]
-    gemini_client.save_settings(settings)
+    existing = gemini_client.get_settings()
+    updated = _preserve_secrets(settings, existing)
+    gemini_client.save_settings(updated)
     return {"status": "ok"}
 
 @router.post("/cloud/test")

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -155,6 +155,8 @@ _SECRET_RAW: list[str] = [
     # OpenAI
     r"sk-[A-Za-z0-9\-_]{20,}",
     r"sk-proj-[A-Za-z0-9\-_]{20,}",
+    # Google API Key
+    r"AIza[a-zA-Z0-9_-]{35}",
     # Slack
     r"xox[bpars]-[A-Za-z0-9\-]{10,}",
     # AWS

--- a/backend/tools/ast_analyzer.py
+++ b/backend/tools/ast_analyzer.py
@@ -6,6 +6,7 @@ from typing import Any
 import os
 import re
 from pathlib import Path
+from backend.config import PROJECT_ROOT
 from .base import BaseTool
 
 class ASTAnalyzerTool(BaseTool):
@@ -31,7 +32,7 @@ class ASTAnalyzerTool(BaseTool):
     async def execute(self, **kwargs) -> dict[str, Any]:
         term = kwargs.get("search_term")
         ext = kwargs.get("file_extension", ".py").lower()
-        cwd = Path(r"c:\Users\Sam Deiter\Documents\GitHub\LocalMind")
+        cwd = PROJECT_ROOT
         
         matches = []
         pattern = re.compile(rf"(class|def|const|let|var)\s+{term}[\(\s:]")

--- a/tests/test_settings_security.py
+++ b/tests/test_settings_security.py
@@ -1,0 +1,119 @@
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from backend.server import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_settings(tmp_path):
+    notif_file = tmp_path / "notification_settings.json"
+    cloud_file = tmp_path / "cloud_settings.json"
+
+    with patch("backend.notifications.SETTINGS_FILE", notif_file), \
+         patch("backend.gemini_client.CLOUD_SETTINGS_FILE", cloud_file):
+        yield notif_file, cloud_file
+
+def test_notification_settings_masking(mock_settings):
+    notif_file, _ = mock_settings
+    original_settings = {
+        "enabled": True,
+        "method": "email-to-sms",
+        "phone": "1234567890",
+        "carrier": "verizon",
+        "smtp_user": "user@example.com",
+        "smtp_pass": "supersecretpassword",
+        "twilio_sid": "AC12345",
+        "twilio_auth_token": "secret_token"
+    }
+    notif_file.write_text(json.dumps(original_settings))
+
+    # Mock authentication to bypass it
+    with patch("backend.security.auth.authenticate_request", return_value={"role": "admin"}):
+        response = client.get("/api/settings/notifications")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify sensitive fields are masked
+        assert data["smtp_pass"] == "****"
+        assert data["twilio_auth_token"] == "****"
+        # Non-sensitive fields should be intact
+        assert data["phone"] == "1234567890"
+
+def test_notification_settings_preservation(mock_settings):
+    notif_file, _ = mock_settings
+    original_settings = {
+        "enabled": True,
+        "method": "email-to-sms",
+        "phone": "1234567890",
+        "carrier": "verizon",
+        "smtp_user": "user@example.com",
+        "smtp_pass": "supersecretpassword",
+        "twilio_sid": "AC12345",
+        "twilio_auth_token": "secret_token"
+    }
+    notif_file.write_text(json.dumps(original_settings))
+
+    updated_settings = {
+        "enabled": True,
+        "method": "email-to-sms",
+        "phone": "0987654321",
+        "carrier": "att",
+        "smtp_user": "newuser@example.com",
+        "smtp_pass": "****", # Masked value sent from UI
+        "twilio_sid": "AC12345",
+        "twilio_auth_token": "****" # Masked value sent from UI
+    }
+
+    with patch("backend.security.auth.authenticate_request", return_value={"role": "admin"}):
+        response = client.post("/api/settings/notifications", json=updated_settings)
+        assert response.status_code == 200
+
+        # Verify original secrets are preserved
+        saved_settings = json.loads(notif_file.read_text())
+        assert saved_settings["smtp_pass"] == "supersecretpassword"
+        assert saved_settings["twilio_auth_token"] == "secret_token"
+        assert saved_settings["phone"] == "0987654321"
+
+def test_cloud_settings_masking(mock_settings):
+    _, cloud_file = mock_settings
+    original_settings = {
+        "api_key": "AIzaSy_very_secret_key"
+    }
+    cloud_file.write_text(json.dumps(original_settings))
+
+    with patch("backend.security.auth.authenticate_request", return_value={"role": "admin"}):
+        response = client.get("/api/settings/cloud")
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify sensitive fields are masked
+        assert data["api_key"] == "****"
+
+def test_cloud_settings_preservation(mock_settings):
+    _, cloud_file = mock_settings
+    original_settings = {
+        "api_key": "AIzaSy_very_secret_key"
+    }
+    cloud_file.write_text(json.dumps(original_settings))
+
+    updated_settings = {
+        "api_key": "****" # Masked value sent from UI
+    }
+
+    with patch("backend.security.auth.authenticate_request", return_value={"role": "admin"}):
+        response = client.post("/api/settings/cloud", json=updated_settings)
+        assert response.status_code == 200
+
+        # Verify original secrets are preserved
+        saved_settings = json.loads(cloud_file.read_text())
+        assert saved_settings["api_key"] == "AIzaSy_very_secret_key"
+
+def test_google_api_key_scrubbing():
+    from backend.security.prompt_guard import PromptGuard
+    guard = PromptGuard("strict")
+    text = "My Google key is AIzaSyA1234567890abcdefghijklmnopqrstuvwx"
+    result = guard.validate_output(text)
+    assert "[REDACTED]" in result.cleaned_text
+    assert "AIzaSy" not in result.cleaned_text


### PR DESCRIPTION
This security enhancement addresses sensitive data exposure in several areas:

1. **Settings API**: Previously, raw credentials like `smtp_pass` and `twilio_auth_token` were sent to the frontend. I implemented a centralized `_mask_settings` helper that replaces these with `****` in GET responses. I also added a `_preserve_secrets` helper that allows the frontend to send back the masked placeholder to indicate the existing secret should be kept, which is essential for updating other settings without re-entering credentials.

2. **Prompt Injection Defense**: Added the Google API key regex (`AIza...`) to `PromptGuard`'s secret patterns. This ensures that if the agent manages to leak its own cloud configuration in output, it is scrubbed before reaching the user.

3. **Code Portability**: Fixed a hardcoded absolute path in `ASTAnalyzerTool` that pointed to a specific user's local directory, replacing it with `PROJECT_ROOT`.

4. **Testing**: Added `tests/test_settings_security.py` to verify that masking and preservation work as intended and that the Google API key is correctly scrubbed by the `PromptGuard`.

5. **Documentation**: Recorded the "Masking Sensitive Settings with Preservation" pattern in the Sentinel journal.

Additionally, I initialized the `backend/metacognition/models` directory with required dataclasses to resolve `ModuleNotFoundError` during test execution.

---
*PR created automatically by Jules for task [4057400165580194594](https://jules.google.com/task/4057400165580194594) started by @SamDeiter*