### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive credential leakage in settings API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-07-05 - Masked Secret Preservation Pattern
+**Vulnerability:** Redacting secrets in API responses (e.g., `****`) can lead to accidental corruption if the client submits the masked string back during a settings update, overwriting the real secret with the mask.
+**Learning:** Manual masking in individual routes is error-prone and often inconsistent (e.g., different mask lengths or omitted fields).
+**Prevention:** Use a centralized `_mask_settings` helper for all GET responses. In POST handlers, explicitly check if a sensitive field matches the mask string and restore the original value from persistent storage before saving.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -36,6 +36,15 @@ def _save_plaintext_profile(user_id: str, profile: dict) -> None:
     _PROFILE_JSON_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+def _mask_settings(settings: dict) -> dict:
+    """Mask sensitive fields in a settings dictionary without mutating original."""
+    masked = settings.copy()
+    for field in ["api_key", "smtp_pass", "twilio_auth_token"]:
+        if masked.get(field):
+            masked[field] = "****"
+    return masked
+
+
 def _load_profile(user_id: str, enc) -> dict | None:
     """Load a user profile, decrypting if necessary."""
     # Try encrypted first
@@ -125,28 +134,27 @@ async def get_user_profile(user_id: str = "default"):
 @router.get("/settings/notifications")
 async def get_notification_settings():
     """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    return _mask_settings(notifications.get_settings())
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
     """Update phone, carrier, and enable/disable status."""
+    current = notifications.get_settings()
+    for field in ["smtp_pass", "twilio_auth_token"]:
+        if settings.get(field) == "****" and current.get(field):
+            settings[field] = current[field]
     notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    return {"status": "ok", "settings": _mask_settings(settings)}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():
     """Return current cloud configuration (Gemini)."""
-    settings = gemini_client.get_settings()
-    if settings.get("api_key"):
-        key = settings["api_key"]
-        settings["api_key"] = "*" * (len(key) - 4) + key[-4:] if len(key) > 4 else "****"
-    return settings
+    return _mask_settings(gemini_client.get_settings())
 
 @router.post("/settings/cloud")
 async def update_cloud_settings(settings: dict):
     """Update Gemini API key."""
-    incoming_key = settings.get("api_key", "")
-    if incoming_key.startswith("****"):
+    if settings.get("api_key") == "****":
         current = gemini_client.get_settings()
         if current.get("api_key"):
             settings["api_key"] = current["api_key"]

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -166,6 +166,8 @@ _SECRET_RAW: list[str] = [
     r"ghs_[A-Za-z0-9]{36}",
     r"gho_[A-Za-z0-9]{36}",
     r"github_pat_[A-Za-z0-9_]{82}",
+    # Google API Key
+    r"AIza[a-zA-Z0-9_-]{35}",
     # Generic high-entropy tokens (≥32 alphanum chars in non-prose context)
     r'(?<![A-Za-z0-9])([A-Za-z0-9+/=]{32,})(?![A-Za-z0-9])',
 ]

--- a/tests/test_settings_security.py
+++ b/tests/test_settings_security.py
@@ -1,0 +1,91 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from backend.routes.settings import _mask_settings, get_notification_settings, update_notification_settings, get_cloud_settings, update_cloud_settings
+from backend.security.prompt_guard import _scrub_secrets
+
+def test_mask_settings_redacts_sensitive_fields():
+    settings = {
+        "api_key": "secret-api-key",
+        "smtp_pass": "secret-smtp-pass",
+        "twilio_auth_token": "secret-twilio-token",
+        "other_field": "public-info"
+    }
+    masked = _mask_settings(settings)
+    assert masked["api_key"] == "****"
+    assert masked["smtp_pass"] == "****"
+    assert masked["twilio_auth_token"] == "****"
+    assert masked["other_field"] == "public-info"
+    # Ensure original is not mutated
+    assert settings["api_key"] == "secret-api-key"
+
+def test_mask_settings_handles_missing_fields():
+    settings = {"other_field": "public-info"}
+    masked = _mask_settings(settings)
+    assert masked == settings
+
+@pytest.mark.asyncio
+@patch("backend.notifications.get_settings")
+async def test_get_notification_settings_is_masked(mock_get):
+    mock_get.return_value = {
+        "smtp_pass": "supersecret",
+        "phone": "123456"
+    }
+    result = await get_notification_settings()
+    assert result["smtp_pass"] == "****"
+    assert result["phone"] == "123456"
+
+@pytest.mark.asyncio
+@patch("backend.notifications.get_settings")
+@patch("backend.notifications.save_settings")
+async def test_update_notification_settings_preserves_secrets(mock_save, mock_get):
+    mock_get.return_value = {
+        "smtp_pass": "original-pass",
+        "twilio_auth_token": "original-token"
+    }
+
+    # User sends masked values
+    new_settings = {
+        "smtp_pass": "****",
+        "twilio_auth_token": "****",
+        "phone": "999999"
+    }
+
+    result = await update_notification_settings(new_settings)
+
+    # Verify save_settings was called with original values
+    saved = mock_save.call_args[0][0]
+    assert saved["smtp_pass"] == "original-pass"
+    assert saved["twilio_auth_token"] == "original-token"
+    assert saved["phone"] == "999999"
+
+    # Verify return value is masked
+    assert result["settings"]["smtp_pass"] == "****"
+
+@pytest.mark.asyncio
+@patch("backend.gemini_client.get_settings")
+async def test_get_cloud_settings_is_masked(mock_get):
+    mock_get.return_value = {"api_key": "ai-key-123"}
+    result = await get_cloud_settings()
+    assert result["api_key"] == "****"
+
+@pytest.mark.asyncio
+@patch("backend.gemini_client.get_settings")
+@patch("backend.gemini_client.save_settings")
+async def test_update_cloud_settings_preserves_secrets(mock_save, mock_get):
+    mock_get.return_value = {"api_key": "original-api-key"}
+
+    new_settings = {"api_key": "****"}
+    await update_cloud_settings(new_settings)
+
+    saved = mock_save.call_args[0][0]
+    assert saved["api_key"] == "original-api-key"
+
+def test_prompt_guard_scrubs_google_api_key():
+    text = "Here is my key: AIzaSyA1234567890abcdefghijklmnopqrstuvwx and some prose."
+    cleaned, scrubbed = _scrub_secrets(text)
+    assert "AIza" not in cleaned
+    assert "[REDACTED]" in cleaned
+    # The name in _scrub_secrets is derived from the pattern itself for named patterns:
+    # kind: str = pat.pattern[:12]
+    # "AIza[a-zA-Z0-9_-]{35}"[:12] -> "AIza[a-zA-Z0"
+    assert "aiza[a-za-z0" in str(scrubbed).lower()


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** 
Sensitive credentials (`smtp_pass`, `twilio_auth_token`) were leaked in plaintext via the `/api/settings/notifications` endpoint. Additionally, manual masking for `api_key` in the cloud settings route was inconsistent and did not handle secret preservation during updates correctly across all sensitive fields.

🎯 **Impact:** 
Exposure of third-party service credentials (SMTP, Twilio) could lead to unauthorized service usage, spam, or information disclosure.

🔧 **Fix:** 
- Introduced a private helper `_mask_settings(settings: dict) -> dict` in `backend/routes/settings.py` to centralize and deduplicate masking logic for all sensitive fields.
- Updated `get_notification_settings` and `get_cloud_settings` to use this helper.
- Implemented logic in `update_notification_settings` and `update_cloud_settings` to detect masked values (`****`) and restore original secrets from persistent storage, ensuring they aren't accidentally overwritten by placeholders.
- Added the Google API key regex `AIza[a-zA-Z0-9_-]{35}` to `backend/security/prompt_guard.py` to ensure it is scrubbed from logs and LLM outputs globally.

✅ **Verification:** 
- Created `tests/test_settings_security.py` with 7 test cases covering masking, preservation, and scrubbing.
- Verified all tests pass via `pytest`.
- Confirmed no regressions in existing security tests (`tests/test_security.py`, `tests/test_terminal_security.py`).

---
*PR created automatically by Jules for task [3136148613587522302](https://jules.google.com/task/3136148613587522302) started by @SamDeiter*