### PR TITLE
🛡️ Sentinel: Fix path and URL prefix bypass vulnerabilities

### DIFF
--- a/backend/security/paths.py
+++ b/backend/security/paths.py
@@ -179,24 +179,11 @@ def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:
             f"Cannot resolve candidate path {candidate!r}: {exc}"
         ) from exc
 
-    # --- Enforce jail via string prefix comparison -------------------------
-    # We must compare strings (not Path parents) so that a jail at
-    # /data/uploads does NOT match /data/uploads_evil.
-    # Add the OS separator to avoid that exact prefix-collision scenario.
-    resolved_base_str = str(resolved_base)
-    resolved_candidate_str = str(resolved_candidate)
-
-    # Normalise case on Windows (NTFS is case-insensitive).
-    if os.name == "nt":
-        resolved_base_str = resolved_base_str.lower()
-        resolved_candidate_str = resolved_candidate_str.lower()
-
-    jail_prefix = resolved_base_str.rstrip(os.sep) + os.sep
-
-    if not (
-        resolved_candidate_str == resolved_base_str.rstrip(os.sep)
-        or resolved_candidate_str.startswith(jail_prefix)
-    ):
+    # --- Enforce jail ------------------------------------------------------
+    # Use is_relative_to for robust path boundary matching (Python 3.9+).
+    # This correctly handles case-insensitivity on Windows and prevents
+    # prefix collisions (e.g. /app/data vs /app/data_evil).
+    if not resolved_candidate.is_relative_to(resolved_base):
         logger.warning(
             "Path escape attempt: %r resolved to %r, outside jail %r",
             user_path_str,

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -488,7 +488,7 @@ class PromptGuard:
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
                         resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        if not resolved.is_relative_to(job_dir.resolve()):
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,7 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,10 +76,17 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
-    for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
-            if allowed_method == "*" or allowed_method == method_upper:
-                return True
+    try:
+        target_path = PurePosixPath(path)
+        for allowed_method, allowed_prefix in permissions:
+            allowed_path = PurePosixPath(allowed_prefix)
+            # Use is_relative_to for robust path boundary matching (Python 3.9+)
+            if target_path.is_relative_to(allowed_path):
+                if allowed_method == "*" or allowed_method == method_upper:
+                    return True
+    except ValueError:
+        # Should not happen with valid URL paths
+        pass
     return False
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,8 +10,8 @@ Constants live in backend/config.py.
 """
 
 import logging
+from pathlib import Path, PurePosixPath
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -291,11 +291,14 @@ async def auth_middleware(request: Request, call_next):
     path = request.url.path
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    target_path = PurePosixPath(path)
+    if path in _AUTH_SKIP_EXACT or any(target_path.is_relative_to(PurePosixPath(p)) for p in _AUTH_SKIP_PREFIXES):
         return await call_next(request)
 
     # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    if target_path.is_relative_to(PurePosixPath("/api")):
+        # Explicitly allow /api/health if it exists and should be public,
+        # but for now, we follow the previous logic which was any /api/
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:**
The application utilized string-based `.startswith()` checks for several critical security boundaries, including:
1. **RBAC:** Checking if a user's role was permitted to access a specific API path prefix.
2. **Authentication Middleware:** Deciding which routes should skip authentication.
3. **PromptGuard:** Ensuring LLM-requested file paths stayed within the job's sandbox directory.

String-based prefix matching is vulnerable to bypasses because it does not respect path boundaries. For example, a check for `/api` would incorrectly match `/api_secret`, and a check for `/tmp/job` would match `/tmp/job_evil`.

🎯 **Impact:**
An attacker could access unauthorized API endpoints or escape sandbox directories by carefully crafting paths that share a string prefix with allowed locations.

🔧 **Fix:**
I have replaced all identified unsafe `.startswith()` calls in security logic with `pathlib.Path.is_relative_to` (for file paths) and `pathlib.PurePosixPath.is_relative_to` (for URL routes). These methods ensure that the target path is a true child of the allowed base path, respecting directory and segment boundaries.

✅ **Verification:**
- Created and executed a reproduction script `reproduce_prefix_bypass.py` that confirmed the vulnerabilities existed and were successfully closed by the fix.
- Ran existing security test suites (`tests/test_security.py`) to ensure no regressions in path jailing logic.
- Addressed code review feedback to ensure `Path.is_relative_to` correctly handles cross-platform case-insensitivity on Windows while remaining robust on POSIX.


---
*PR created automatically by Jules for task [12496333997578387054](https://jules.google.com/task/12496333997578387054) started by @SamDeiter*