### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path jailing vulnerability in PromptGuard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-14 - Argument Mismatch and Insecure Prefix Check in Path Jailing
+**Vulnerability:** `PromptGuard` used an insecure string-based `.startswith()` check for path jailing and called `safe_resolve` with swapped arguments. This led to nonsensical resolved paths (e.g., `/etc/passwd/tmp/job`) and potentially allowed prefix-collision bypasses (e.g., `/tmp/job_secret` matching `/tmp/job`).
+**Learning:** Argument order mismatch in security critical functions can silently break protection. Standardizing on path-aware containment checks like `is_relative_to` is safer than string prefixing.
+**Prevention:** Always use `Path.is_relative_to` for containment checks and ensure unit tests verify both traversal and prefix-collision scenarios.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,9 +29,9 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
+    def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:  # type: ignore[misc]
         """Fallback: resolve without jail check."""
-        return Path(path).resolve()
+        return (Path(base_dir) / str(user_path)).resolve()
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -487,8 +487,8 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        resolved = safe_resolve(job_dir, arg_value)
+                        if not resolved.is_relative_to(job_dir.resolve()):
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path jailing in `PromptGuard` was broken due to an argument order mismatch when calling `safe_resolve` and the use of an insecure string-based prefix check.
🎯 Impact: An attacker could potentially bypass path jailing to read or write files outside the intended job directory. The incorrect argument order also resulted in invalid path resolutions.
🔧 Fix:
- Corrected the `safe_resolve` argument order in `PromptGuard.validate_tool_call`.
- Fixed the fallback `safe_resolve` signature and implementation in `prompt_guard.py`.
- Replaced the insecure `.startswith()` string check with the path-aware `is_relative_to()` method.
✅ Verification: Verified using a custom reproduction script that confirmed path traversal is now correctly blocked and valid paths are still allowed. Existing security tests were run, with one pre-existing POSIX-specific failure noted as unrelated.

---
*PR created automatically by Jules for task [6542881168444295786](https://jules.google.com/task/6542881168444295786) started by @SamDeiter*