### PR TITLE
🛡️ Sentinel: Fix route prefix collision in RBAC and Middleware

### DIFF
--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,7 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,8 +76,12 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
+    target_path = PurePosixPath(path)
+
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Use PurePosixPath for robust route prefix validation (prevents collisions).
+        prefix_path = PurePosixPath(allowed_prefix)
+        if target_path == prefix_path or target_path.is_relative_to(prefix_path):
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/backend/server.py
+++ b/backend/server.py
@@ -11,7 +11,7 @@ Constants live in backend/config.py.
 
 import logging
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -289,13 +289,14 @@ async def auth_middleware(request: Request, call_next):
     """
     from fastapi.responses import JSONResponse as _JSONResponse
     path = request.url.path
+    path_obj = PurePosixPath(path)
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    if path in _AUTH_SKIP_EXACT or any(path_obj.is_relative_to(p) for p in _AUTH_SKIP_PREFIXES):
         return await call_next(request)
 
     # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    if path_obj.is_relative_to("/api"):
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission

--- a/tests/test_enterprise_security.py
+++ b/tests/test_enterprise_security.py
@@ -1429,3 +1429,35 @@ class TestStartupSecretScanner:
             warnings = StartupSecretScanner.scan_environment()
             safe_hits = [w for w in warnings if w.get("variable") == "SAFE_VAR"]
             assert len(safe_hits) == 0
+
+# ---------------------------------------------------------------------------
+# 6. backend.security.rbac Prefix Collision
+# ---------------------------------------------------------------------------
+
+from backend.security.rbac import _is_allowed
+
+class TestRBACPrefixCollision:
+    """Verify that route prefix collisions are correctly handled (blocked)."""
+
+    def test_prefix_collision_blocked_viewer(self):
+        # viewer has ("GET", "/api/")
+        # Should match subpaths
+        assert _is_allowed("viewer", "GET", "/api/jobs") is True
+        assert _is_allowed("viewer", "GET", "/api/conversations/123") is True
+        # Should NOT match collisions
+        assert _is_allowed("viewer", "GET", "/api_secret") is False
+        assert _is_allowed("viewer", "GET", "/api-config") is False
+
+    def test_prefix_collision_blocked_operator(self):
+        # operator has ("POST", "/api/chat")
+        assert _is_allowed("operator", "POST", "/api/chat") is True
+        assert _is_allowed("operator", "POST", "/api/chat/messages") is True
+        # Should NOT match collisions
+        assert _is_allowed("operator", "POST", "/api/chat_malicious") is False
+        assert _is_allowed("operator", "POST", "/api/chat-admin") is False
+
+    def test_exact_match_at_root(self):
+        # admin has ("*", "/api/")
+        assert _is_allowed("admin", "GET", "/api") is True
+        assert _is_allowed("admin", "GET", "/api/") is True
+        assert _is_allowed("admin", "GET", "/api/anything") is True


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement]

🚨 **Severity:** MEDIUM (Defense in Depth)

💡 **Vulnerability:** Route prefix collision in authorization logic. Using `.startswith()` to validate route access is vulnerable to string-prefix collisions. For example, a rule allowing `GET /api` would inadvertently allow `GET /api_secret` because they share the same string prefix.

🎯 **Impact:** Potential authorization bypass where unauthorized endpoints starting with a protected prefix could be accessed if not carefully named.

🔧 **Fix:** Replaced string-based `.startswith()` with `pathlib.PurePosixPath.is_relative_to()`. This ensures that route matching respects path boundaries and directory separators, correctly identifying only sub-paths or exact matches.

✅ **Verification:**
- Added `TestRBACPrefixCollision` to `tests/test_enterprise_security.py`.
- Verified that `/api_secret` is correctly blocked when only `/api` is permitted.
- Ran full test suite; 244 tests passed (1 unrelated environment-specific failure in `test_traversal_backslash_blocked`).


---
*PR created automatically by Jules for task [9323957721963910761](https://jules.google.com/task/9323957721963910761) started by @SamDeiter*