### PR TITLE
🎨 Palette: Add "Stop Generation" button

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -330,10 +330,17 @@
                                         <span class="material-symbols-outlined text-lg">volume_up</span>
                                     </button>
                                 </div>
-                                <button id="sendBtn" aria-label="Send Message" title="Send this message"
-                                    class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
-                                    <span class="material-symbols-outlined text-lg">arrow_upward</span>
-                                </button>
+                                <div class="flex items-center gap-1">
+                                    <button id="stopBtn" aria-label="Stop Generation" title="Stop Generation"
+                                        class="p-2 rounded-lg text-red-500 hover:text-red-400 hover:bg-red-500/10 transition-all"
+                                        style="display: none;">
+                                        <span class="material-symbols-outlined text-lg">stop_circle</span>
+                                    </button>
+                                    <button id="sendBtn" aria-label="Send Message" title="Send this message"
+                                        class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
+                                        <span class="material-symbols-outlined text-lg">arrow_upward</span>
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Implemented a "Stop Generation" button in the chat interface. This is a micro-UX improvement that provides users with immediate control to terminate ongoing AI response generation. The implementation adds the necessary HTML structure in `frontend/index.html`, which integrates with pre-existing JavaScript logic for handling stream abortion via `AbortController`. The button is styled with Tailwind CSS and uses the `stop_circle` Material Symbol for clear visual intent. It is hidden by default and programmatically shown during active chat streaming.

---
*PR created automatically by Jules for task [861660064977145852](https://jules.google.com/task/861660064977145852) started by @SamDeiter*