### PR TITLE
🛡️ Sentinel: [HIGH] Fix path jailing logic in PromptGuard

### DIFF
--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,9 +29,9 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
+    def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:  # type: ignore[misc]
         """Fallback: resolve without jail check."""
-        return Path(path).resolve()
+        return Path(base_dir).joinpath(user_path).resolve()
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -487,8 +487,8 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        resolved = safe_resolve(job_dir, arg_value)
+                        if not resolved.is_relative_to(job_dir.resolve()):
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )


### PR DESCRIPTION
I identified a high-priority security vulnerability in `backend/security/prompt_guard.py` where the arguments to `safe_resolve` were swapped in the tool call validation logic. This swap caused the "jail" directory to be treated as the user-supplied path and the user-supplied path to be treated as the jail, effectively allowing an attacker to bypass the jailing mechanism by providing `/` as a path.

I resolved this by:
1. Correcting the argument order in the `safe_resolve` call.
2. Updating the internal fallback `safe_resolve` in `prompt_guard.py` to maintain signature compatibility and correct logic.
3. Replacing the `startswith` string check with `Path.is_relative_to` for a more robust and cleaner security boundary check.

Verified the fix with reproduction scripts (demonstrating that `/` no longer bypasses jailing) and ran the existing security test suite.

---
*PR created automatically by Jules for task [8940032029869726075](https://jules.google.com/task/8940032029869726075) started by @SamDeiter*