### PR TITLE
🛡️ Sentinel: [HIGH] Fix path prefix collision in RBAC and Auth middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - Path Prefix Collision in RBAC and Auth Middleware
+**Vulnerability:** Using `path.startswith(prefix)` for security checks (RBAC or Auth middleware) is vulnerable to prefix collision bypasses. For example, `/api/chat_secrets` matches the prefix `/api/chat`, potentially granting unintended access.
+**Learning:** `is_relative_to` in `pathlib` is a safer alternative but it can raise `ValueError` on some Python versions (3.9-3.11) if the paths are not related, which can crash the application if not handled.
+**Prevention:** Use `PurePosixPath(path).is_relative_to(prefix)` and always wrap it in a `try...except ValueError` block for cross-version compatibility and robustness.

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,7 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,10 +76,17 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
+    p_path = PurePosixPath(path)
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
-            if allowed_method == "*" or allowed_method == method_upper:
-                return True
+        try:
+            # Use is_relative_to to ensure we respect path boundaries.
+            # path.startswith() is vulnerable to prefix collisions (e.g. /api/chat_secrets matching /api/chat).
+            if p_path.is_relative_to(allowed_prefix):
+                if allowed_method == "*" or allowed_method == method_upper:
+                    return True
+        except ValueError:
+            # is_relative_to raises ValueError if paths are not related
+            continue
     return False
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -11,7 +11,7 @@ Constants live in backend/config.py.
 
 import logging
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -289,13 +289,25 @@ async def auth_middleware(request: Request, call_next):
     """
     from fastapi.responses import JSONResponse as _JSONResponse
     path = request.url.path
+    p_path = PurePosixPath(path)
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
-        return await call_next(request)
+    # Security: Use is_relative_to instead of .startswith() to prevent prefix collisions (e.g. /api_secret)
+    try:
+        if path in _AUTH_SKIP_EXACT or any(p_path.is_relative_to(p) for p in _AUTH_SKIP_PREFIXES):
+            return await call_next(request)
+    except ValueError:
+        # is_relative_to raises ValueError if paths are not related in some Python versions
+        pass
 
     # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    is_api_route = False
+    try:
+        is_api_route = p_path.is_relative_to("/api")
+    except ValueError:
+        pass
+
+    if is_api_route:
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission

--- a/tests/test_auth_rbac.py
+++ b/tests/test_auth_rbac.py
@@ -638,6 +638,12 @@ class TestIsAllowed:
     def test_unknown_role_returns_false(self):
         assert _is_allowed("nobody", "GET", "/api/stuff") is False
 
+    def test_prefix_collision_disallowed(self):
+        """Security: Verify that /api/chat_secrets does not match /api/chat."""
+        # operator has /api/chat but NOT /api/chat_secrets
+        assert _is_allowed("operator", "POST", "/api/chat/stream") is True
+        assert _is_allowed("operator", "POST", "/api/chat_secrets") is False
+
 
 # ---------------------------------------------------------------------------
 # 7. TestRequireRole


### PR DESCRIPTION
Fixes a security vulnerability where path prefix matching could allow unauthorized access to endpoints with similar names (e.g. `/api/chat_secrets` matching `/api/chat`). Switches to `pathlib.PurePosixPath.is_relative_to` for robust, path-boundary-aware matching and adds necessary exception handling for cross-version compatibility.

---
*PR created automatically by Jules for task [479497274361074069](https://jules.google.com/task/479497274361074069) started by @SamDeiter*