### PR TITLE
🛡️ Sentinel: Fix RBAC and Auth prefix collision vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - Path Authorization Bypass via Prefix Collision
+**Vulnerability:** Using `str.startswith()` for path-based authorization (RBAC or middleware) allows attackers to bypass security checks by using paths that share a string prefix but are not subdirectories. For example, `/api_secret` would match a check for `/api` if only `startswith` is used.
+**Learning:** String-based prefix matching is not aware of path boundaries (delimiters like `/`).
+**Prevention:** Use `pathlib.PurePosixPath.is_relative_to()` or ensure the prefix ends with a trailing slash. Path-aware methods are preferred for robustness across environments.

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,7 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,10 +76,15 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
+    target_path = PurePosixPath(path)
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
-            if allowed_method == "*" or allowed_method == method_upper:
-                return True
+        try:
+            if target_path.is_relative_to(allowed_prefix):
+                if allowed_method == "*" or allowed_method == method_upper:
+                    return True
+        except ValueError:
+            # is_relative_to raises ValueError if paths are not relative
+            continue
     return False
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -11,7 +11,7 @@ Constants live in backend/config.py.
 
 import logging
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -291,11 +291,12 @@ async def auth_middleware(request: Request, call_next):
     path = request.url.path
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    target_path = PurePosixPath(path)
+    if path in _AUTH_SKIP_EXACT or any(target_path.is_relative_to(p) for p in _AUTH_SKIP_PREFIXES):
         return await call_next(request)
 
     # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    if target_path.is_relative_to("/api"):
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission


### PR DESCRIPTION
🛡️ Sentinel: Fix RBAC and Auth prefix collision vulnerability

The application used string-based `.startswith()` to verify if a requested path was allowed under a certain prefix. This is vulnerable to prefix collision attacks. For example, if `/api/chat` is allowed for an `operator`, a request to `/api/chat_admin` would also be allowed because the string `/api/chat_admin` starts with `/api/chat`.

I have refactored the matching logic in `backend/security/rbac.py` and `backend/server.py` to use `pathlib.PurePosixPath.is_relative_to()`. This method is path-aware and ensures that the target path is a true sub-path (or equal) to the prefix, respecting directory boundaries.

Key changes:
- Updated `_is_allowed` in `backend/security/rbac.py` to use `PurePosixPath.is_relative_to()`.
- Updated `auth_middleware` in `backend/server.py` to use `PurePosixPath.is_relative_to()` for authentication enforcement and bypass checks.
- Added error handling for `ValueError` in the RBAC check to ensure robustness.

Verification:
- Created a reproduction script that confirmed the vulnerability (allowed `/api/chat_admin` for operators).
- Confirmed the fix with the same script (now correctly rejects `/api/chat_admin`).
- Ran the comprehensive test suite `tests/test_auth_rbac.py` and all 103 tests passed.


---
*PR created automatically by Jules for task [11945985445808453970](https://jules.google.com/task/11945985445808453970) started by @SamDeiter*