### PR TITLE
🛡️ Sentinel: Fix RBAC and Auth bypass via path traversal and prefix collision

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - RBAC Bypass via Path Traversal & Prefix Collision
+**Vulnerability:** Authorization logic using `str.startswith()` on request paths was vulnerable to prefix collisions (e.g., `/api_secret` matching a permission for `/api`) and path traversal (e.g., `/api/chat/../admin` matching `/api/chat`).
+**Learning:** `os.path.normpath()` is dangerous for URL paths because it uses platform-specific separators (backslashes on Windows), which `pathlib.PurePosixPath` does not recognize as separators.
+**Prevention:** Use `posixpath.normpath()` combined with `pathlib.PurePosixPath(path).is_relative_to(prefix)` for secure, segment-based path matching. Always wrap `is_relative_to` in `try...except ValueError` as it raises if paths don't share the same root or have mismatched leading slashes.

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,8 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+import posixpath
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,10 +77,26 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
+
+    # Security: use PurePosixPath to avoid prefix collision (e.g. /api vs /api_secret)
+    # and to handle path traversal safely (e.g. /api/../admin).
+    try:
+        # We normalize the path by resolving '..' but without touching the filesystem.
+        # This prevents '/api/chat/../admin' from matching '/api/chat'.
+        p_path = PurePosixPath(posixpath.normpath(path))
+    except Exception:
+        return False
+
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
-            if allowed_method == "*" or allowed_method == method_upper:
-                return True
+        if allowed_method == "*" or allowed_method == method_upper:
+            try:
+                # is_relative_to ensures 'path' is a sub-path of 'allowed_prefix'
+                # based on path segments, not just string prefix.
+                if p_path.is_relative_to(allowed_prefix):
+                    return True
+            except ValueError:
+                # Raised if paths are not relative (e.g. different roots)
+                continue
     return False
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,8 +10,9 @@ Constants live in backend/config.py.
 """
 
 import logging
+import posixpath
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -290,12 +291,27 @@ async def auth_middleware(request: Request, call_next):
     from fastapi.responses import JSONResponse as _JSONResponse
     path = request.url.path
 
+    # Normalize path to prevent traversal-based auth bypass
+    normalized_path = posixpath.normpath(path)
+    p_path = PurePosixPath(normalized_path)
+
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    try:
+        is_skipped = (normalized_path in _AUTH_SKIP_EXACT or
+                    any(p_path.is_relative_to(p) for p in _AUTH_SKIP_PREFIXES))
+    except ValueError:
+        is_skipped = False
+
+    if is_skipped:
         return await call_next(request)
 
     # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    try:
+        is_api = p_path.is_relative_to("/api")
+    except ValueError:
+        is_api = False
+
+    if is_api:
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission

--- a/tests/test_security_rbac_bypass.py
+++ b/tests/test_security_rbac_bypass.py
@@ -1,0 +1,18 @@
+
+from backend.security.rbac import _is_allowed
+
+def test_rbac_prefix_collision_bypass():
+    # 'operator' role has permission for ('POST', '/api/chat')
+    # This should NOT allow 'POST' on '/api/chat_evil'
+    assert _is_allowed("operator", "POST", "/api/chat") is True
+    assert _is_allowed("operator", "POST", "/api/chat/123") is True
+    assert _is_allowed("operator", "POST", "/api/chat_evil") is False, "RBAC bypass detected: /api/chat_evil should not be allowed via /api/chat prefix"
+
+def test_rbac_path_traversal_bypass():
+    # '/api/chat' should not allow '/api/chat/../admin'
+    assert _is_allowed("operator", "POST", "/api/chat/../admin") is False, "RBAC bypass detected: path traversal allowed"
+
+def test_rbac_malformed_path():
+    # Verify that malformed paths don't crash the logic
+    assert _is_allowed("operator", "POST", "invalid_path") is False
+    assert _is_allowed("operator", "POST", "") is False


### PR DESCRIPTION
This PR addresses a critical security vulnerability where the RBAC and authentication middleware could be bypassed using crafted URL paths.

The previous implementation relied on `str.startswith()` for permission checks and skip-auth lists. This was vulnerable to:
1. **Prefix Collisions**: A request to `/api_secret` would incorrectly match an allowed prefix of `/api`.
2. **Path Traversal**: A request to `/public/../api/admin` could potentially bypass authentication if `/public` was in the skip-auth list.

I have refactored the logic to use `posixpath.normpath()` for normalization and `pathlib.PurePosixPath.is_relative_to()` for secure, segment-aware matching. The implementation is platform-independent and includes robustness checks to prevent server crashes on malformed input.

Verification:
- Ran `tests/test_security_rbac_bypass.py` (newly added regression tests).
- Ran `tests/test_auth_rbac.py` (existing test suite).
- All 106 tests passed.

---
*PR created automatically by Jules for task [17499730615238571076](https://jules.google.com/task/17499730615238571076) started by @SamDeiter*