### PR TITLE
🛡️ Sentinel: Fix credential leaks and hardcoded paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-07-05 - Plain-text Credential Exposure in API responses
+**Vulnerability:** Sensitive credentials (like SMTP passwords or API keys) stored in configuration files are often returned in plain text by "get settings" endpoints, making them visible to the frontend and anyone with access to the API.
+**Learning:** Returning full configuration objects directly from the database/file to the client without filtering is a common source of credential leaks.
+**Prevention:** Implement a centralized masking and preservation mechanism. Use a dedicated `_mask_settings` function to replace sensitive fields with a constant mask (e.g., `********`) before sending responses. Use a matching `_preserve_secrets` function during updates to ensure that if the client sends back the mask, the original secret is kept rather than being overwritten.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -9,10 +9,32 @@ from backend import notifications, gemini_client
 router = APIRouter(prefix="/api")
 logger = logging.getLogger("localmind.routes.settings")
 
+SENSITIVE_FIELDS = ["api_key", "smtp_pass"]
+MASK = "********"
+
 # ── User-profile storage paths ───────────────────────────────────────
 _WORKSPACE = Path.home() / "LocalMind_Workspace"
 _PROFILE_ENC_PATH = _WORKSPACE / "user_profile.enc"
 _PROFILE_JSON_PATH = _WORKSPACE / "user_profile.json"
+
+
+def _mask_settings(settings: dict) -> dict:
+    """Replace sensitive values with a mask for API responses."""
+    masked = settings.copy()
+    for field in SENSITIVE_FIELDS:
+        if masked.get(field):
+            masked[field] = MASK
+    return masked
+
+
+def _preserve_secrets(incoming: dict, current: dict) -> dict:
+    """Prevent overwriting real secrets with mask values."""
+    updated = incoming.copy()
+    for field in SENSITIVE_FIELDS:
+        if updated.get(field) == MASK:
+            if current.get(field):
+                updated[field] = current[field]
+    return updated
 
 
 def _get_memory_encryption():
@@ -125,32 +147,29 @@ async def get_user_profile(user_id: str = "default"):
 @router.get("/settings/notifications")
 async def get_notification_settings():
     """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    settings = notifications.get_settings()
+    return _mask_settings(settings)
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
     """Update phone, carrier, and enable/disable status."""
-    notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    current = notifications.get_settings()
+    updated = _preserve_secrets(settings, current)
+    notifications.save_settings(updated)
+    return {"status": "ok", "settings": _mask_settings(updated)}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():
     """Return current cloud configuration (Gemini)."""
     settings = gemini_client.get_settings()
-    if settings.get("api_key"):
-        key = settings["api_key"]
-        settings["api_key"] = "*" * (len(key) - 4) + key[-4:] if len(key) > 4 else "****"
-    return settings
+    return _mask_settings(settings)
 
 @router.post("/settings/cloud")
 async def update_cloud_settings(settings: dict):
     """Update Gemini API key."""
-    incoming_key = settings.get("api_key", "")
-    if incoming_key.startswith("****"):
-        current = gemini_client.get_settings()
-        if current.get("api_key"):
-            settings["api_key"] = current["api_key"]
-    gemini_client.save_settings(settings)
+    current = gemini_client.get_settings()
+    updated = _preserve_secrets(settings, current)
+    gemini_client.save_settings(updated)
     return {"status": "ok"}
 
 @router.post("/cloud/test")

--- a/backend/tools/ast_analyzer.py
+++ b/backend/tools/ast_analyzer.py
@@ -6,6 +6,7 @@ from typing import Any
 import os
 import re
 from pathlib import Path
+from backend.config import PROJECT_ROOT
 from .base import BaseTool
 
 class ASTAnalyzerTool(BaseTool):
@@ -31,7 +32,7 @@ class ASTAnalyzerTool(BaseTool):
     async def execute(self, **kwargs) -> dict[str, Any]:
         term = kwargs.get("search_term")
         ext = kwargs.get("file_extension", ".py").lower()
-        cwd = Path(r"c:\Users\Sam Deiter\Documents\GitHub\LocalMind")
+        cwd = PROJECT_ROOT
         
         matches = []
         pattern = re.compile(rf"(class|def|const|let|var)\s+{term}[\(\s:]")

--- a/tests/repro_security.py
+++ b/tests/repro_security.py
@@ -1,0 +1,61 @@
+import json
+import os
+from pathlib import Path
+import sys
+import asyncio
+from unittest.mock import MagicMock
+
+# Add current directory to sys.path to find 'backend'
+sys.path.append(os.getcwd())
+
+from backend.routes import settings
+
+async def repro():
+    # Setup dummy settings
+    WORKSPACE = Path.home() / "LocalMind_Workspace"
+    SETTINGS_FILE = WORKSPACE / "notification_settings.json"
+    WORKSPACE.mkdir(parents=True, exist_ok=True)
+
+    dummy_settings = {
+        "enabled": True,
+        "method": "email-to-sms",
+        "phone": "1234567890",
+        "carrier": "verizon",
+        "smtp_user": "user@example.com",
+        "smtp_pass": "SECRET_PASSWORD"
+    }
+    SETTINGS_FILE.write_text(json.dumps(dummy_settings))
+
+    # Check what get_notification_settings returns
+    # It's an async function
+    masked_settings = await settings.get_notification_settings()
+    print(f"Masked SMTP Pass: {masked_settings.get('smtp_pass')}")
+
+    if masked_settings.get("smtp_pass") == "SECRET_PASSWORD":
+        print("VULNERABILITY STILL PRESENT: smtp_pass is leaked in plain text")
+    elif masked_settings.get("smtp_pass") == "********":
+        print("FIX VERIFIED: smtp_pass is masked")
+    else:
+        print(f"Unexpected value for smtp_pass: {masked_settings.get('smtp_pass')}")
+
+    # Test preservation
+    incoming = {
+        "enabled": True,
+        "method": "email-to-sms",
+        "phone": "1234567890",
+        "carrier": "verizon",
+        "smtp_user": "user@example.com",
+        "smtp_pass": "********" # The mask
+    }
+
+    await settings.update_notification_settings(incoming)
+
+    # Read raw file to see if secret was preserved
+    raw_settings = json.loads(SETTINGS_FILE.read_text())
+    if raw_settings.get("smtp_pass") == "SECRET_PASSWORD":
+        print("PRESERVATION VERIFIED: secret was not overwritten by mask")
+    else:
+        print(f"PRESERVATION FAILED: secret was overwritten by {raw_settings.get('smtp_pass')}")
+
+if __name__ == "__main__":
+    asyncio.run(repro())


### PR DESCRIPTION
This PR addresses two security issues:
1. **Credential Exposure:** SMTP passwords and API keys were being returned in plain text via settings endpoints. I implemented a centralized `_mask_settings` and `_preserve_secrets` mechanism in `backend/routes/settings.py` to ensure these secrets are always masked in transit and preserved during updates.
2. **Environment Information Leakage:** A hardcoded developer path was found in `backend/tools/ast_analyzer.py`. I replaced it with `PROJECT_ROOT` to prevent leaking the host's directory structure and ensure the tool works across different environments.

Verification:
- Created a reproduction script `tests/repro_security.py` that confirms masking and preservation work as expected.
- Verified that `ASTAnalyzerTool` now correctly uses the project root.
- All relevant tests in `tests/test_notifications.py` and `tests/test_gemini_client.py` passed.

---
*PR created automatically by Jules for task [14664030221753891836](https://jules.google.com/task/14664030221753891836) started by @SamDeiter*