### PR TITLE
🛡️ Sentinel: Fix RBAC and Auth prefix collision vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-24 - RBAC and Auth prefix collision via `.startswith()`
+**Vulnerability:** Using `str.startswith()` for URL path-based authorization (RBAC) or authentication middleware is vulnerable to prefix collisions. For example, a rule for `/api/chat` incorrectly matches a request for `/api/chat_evil`.
+**Learning:** String-based prefix matching does not respect URL path segments.
+**Prevention:** Use `posixpath.normpath()` followed by `pathlib.PurePosixPath.is_relative_to()` to ensure segment-aware matching. Always wrap `is_relative_to` in `try...except ValueError` to handle unrelated paths.

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,8 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+import posixpath
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,8 +77,20 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
+
+    # Security: Normalize path to prevent traversal/collision bypasses.
+    normalized_path = posixpath.normpath(path)
+    path_obj = PurePosixPath(normalized_path)
+
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Security: Use segment-aware matching (is_relative_to) instead of .startswith()
+        # to prevent prefix collisions like /api/chat matching /api/chat_evil
+        try:
+            is_match = path_obj.is_relative_to(allowed_prefix)
+        except ValueError:
+            is_match = False
+
+        if is_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,8 +10,9 @@ Constants live in backend/config.py.
 """
 
 import logging
+import posixpath
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -289,13 +290,29 @@ async def auth_middleware(request: Request, call_next):
     """
     from fastapi.responses import JSONResponse as _JSONResponse
     path = request.url.path
+    normalized_path = posixpath.normpath(path)
+    path_obj = PurePosixPath(normalized_path)
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    if normalized_path in _AUTH_SKIP_EXACT:
         return await call_next(request)
 
+    for prefix in _AUTH_SKIP_PREFIXES:
+        try:
+            if path_obj.is_relative_to(prefix):
+                return await call_next(request)
+        except ValueError:
+            continue
+
     # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    is_api = False
+    try:
+        if path_obj.is_relative_to("/api"):
+            is_api = True
+    except ValueError:
+        pass
+
+    if is_api:
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission

--- a/tests/repro_security.py
+++ b/tests/repro_security.py
@@ -1,0 +1,50 @@
+
+import pytest
+import posixpath
+from pathlib import PurePosixPath
+from backend.security.rbac import _is_allowed
+import asyncio
+
+def test_rbac_prefix_collision():
+    # operator is allowed /api/chat
+    # should NOT match /api/chat_evil
+    assert _is_allowed("operator", "POST", "/api/chat") is True
+    assert _is_allowed("operator", "POST", "/api/chat_evil") is False
+    assert _is_allowed("operator", "POST", "/api/chat/123") is True
+
+def test_rbac_normalization():
+    # traversal should be normalized
+    assert _is_allowed("operator", "POST", "/api/chat/../jobs") is True # /api/jobs
+    assert _is_allowed("operator", "POST", "/api/../secret") is False # /secret (not starting with /api)
+
+def test_auth_middleware_logic():
+    # Verify the segment-aware matching logic
+    _AUTH_SKIP_PREFIXES = ("/health", "/docs", "/static/")
+
+    def check_skip(path):
+        normalized_path = posixpath.normpath(path)
+        path_obj = PurePosixPath(normalized_path)
+        for prefix in _AUTH_SKIP_PREFIXES:
+            try:
+                if path_obj.is_relative_to(prefix):
+                    return True
+            except ValueError:
+                continue
+        return False
+
+    assert check_skip("/health/ready") is True
+    assert check_skip("/static/main.js") is True
+    assert check_skip("/static_secret") is False
+    assert check_skip("/health_secret") is False
+
+    def check_api(path):
+        normalized_path = posixpath.normpath(path)
+        path_obj = PurePosixPath(normalized_path)
+        try:
+            return path_obj.is_relative_to("/api")
+        except ValueError:
+            return False
+
+    assert check_api("/api/chat") is True
+    assert check_api("/api_secret") is False
+    assert check_api("/api/../secret") is False


### PR DESCRIPTION
### 🛡️ Sentinel: Fix RBAC and Auth prefix collision vulnerabilities

🚨 **Severity:** HIGH
💡 **Vulnerability:** The RBAC layer and authentication middleware used `str.startswith()` for URL path matching. This is vulnerable to prefix collisions where a request for a non-existent or malicious endpoint like `/api/chat_evil` would incorrectly match a permission rule for `/api/chat`. It also failed to account for path normalization, potentially allowing bypasses via `..` segments if not handled by the underlying framework in exactly the same way.

🎯 **Impact:** Unauthorized access to sensitive endpoints or bypass of authentication for specifically crafted URL paths that share prefixes with allowed/public routes.

🔧 **Fix:** 
- Implemented segment-aware matching using `pathlib.PurePosixPath.is_relative_to()`.
- Added path normalization using `posixpath.normpath()` prior to matching to ensure a consistent canonical state.
- Wrapped matching logic in `try...except ValueError` to safely handle unrelated or malformed paths.

✅ **Verification:** 
- Added a comprehensive regression test suite in `tests/repro_security.py`.
- Verified that all 103 existing tests in `tests/test_auth_rbac.py` pass.
- Confirmed with reproduction scripts that `/api/chat_evil` is now correctly denied when only `/api/chat` is permitted.

---
*PR created automatically by Jules for task [6033665579528383615](https://jules.google.com/task/6033665579528383615) started by @SamDeiter*