### PR TITLE
🛡️ Sentinel: Fix hardcoded path in ASTAnalyzerTool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-05-24 - Hardcoded environment-specific paths
+**Vulnerability:** Hardcoded absolute paths (e.g., `C:\Users\...`) leak developer environment details and cause tools to fail in different environments (e.g., Linux containers).
+**Learning:** Tools that perform file system traversal must use relative paths or project-relative roots (like `PROJECT_ROOT`) to remain portable and secure.
+**Prevention:** Always use a centralized configuration variable for the project root and ensure all tool-driven file operations are relative to it.

--- a/backend/tools/ast_analyzer.py
+++ b/backend/tools/ast_analyzer.py
@@ -6,6 +6,7 @@ from typing import Any
 import os
 import re
 from pathlib import Path
+from backend.config import PROJECT_ROOT
 from .base import BaseTool
 
 class ASTAnalyzerTool(BaseTool):
@@ -31,7 +32,7 @@ class ASTAnalyzerTool(BaseTool):
     async def execute(self, **kwargs) -> dict[str, Any]:
         term = kwargs.get("search_term")
         ext = kwargs.get("file_extension", ".py").lower()
-        cwd = Path(r"c:\Users\Sam Deiter\Documents\GitHub\LocalMind")
+        cwd = PROJECT_ROOT
         
         matches = []
         pattern = re.compile(rf"(class|def|const|let|var)\s+{term}[\(\s:]")

--- a/tests/repro_security.py
+++ b/tests/repro_security.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+from backend.config import PROJECT_ROOT
+from backend.tools.ast_analyzer import ASTAnalyzerTool
+
+class TestHardcodedPath(unittest.TestCase):
+    def test_ast_analyzer_uses_project_root(self):
+        # This test verifies that ASTAnalyzerTool uses PROJECT_ROOT instead of a hardcoded Windows path
+        tool = ASTAnalyzerTool()
+        # We can't easily check the local variable 'cwd' inside 'execute',
+        # but we can check the file content itself or verify it works on this system.
+
+        path = Path("backend/tools/ast_analyzer.py")
+        content = path.read_text()
+
+        self.assertNotIn(r"c:\Users\Sam Deiter", content)
+        self.assertIn("cwd = PROJECT_ROOT", content)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed a security and portability issue in `ASTAnalyzerTool` where a hardcoded absolute path was used for codebase searches. The hardcoded path leaked developer environment details and caused the tool to fail on non-Windows systems. I replaced it with the project's centralized `PROJECT_ROOT` constant.

Key changes:
- Modified `backend/tools/ast_analyzer.py` to use `PROJECT_ROOT`.
- Created `tests/repro_security.py` with a regression test.
- Updated `.jules/sentinel.md` with learnings about hardcoded paths.

---
*PR created automatically by Jules for task [2178672833323476339](https://jules.google.com/task/2178672833323476339) started by @SamDeiter*