### PR TITLE
🛡️ Sentinel: Mask SMTP Password in Settings API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-05-15 - Credential Leak in POST/PUT API Responses
+**Vulnerability:** Masking sensitive credentials (like SMTP passwords) in GET responses is insufficient if the same data is returned in plain text within POST/PUT responses.
+**Learning:** Developers often forget that "Echoing" the updated object in a response can bypass front-end masking. Additionally, logic to preserve masked values during round-trips must handle all possible string lengths correctly.
+**Prevention:** Always use a central masking utility to scrub sensitive fields from ALL API responses. Ensure that "restoration" logic (which checks if a masked value was sent back) uses a consistent marker (e.g., always starting with 4+ stars) that cannot be confused with short real passwords.

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -36,6 +36,17 @@ def _save_plaintext_profile(user_id: str, profile: dict) -> None:
     _PROFILE_JSON_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+def _mask_notification_settings(settings: dict) -> dict:
+    """Return a copy of notification settings with sensitive fields masked."""
+    masked = settings.copy()
+    if masked.get("smtp_pass"):
+        pw = str(masked["smtp_pass"])
+        # Security: Mask SMTP password to prevent plain-text exposure.
+        # Always use at least four stars to ensure update detects it on round-trip.
+        masked["smtp_pass"] = "****" + (pw[-4:] if len(pw) > 4 else "")
+    return masked
+
+
 def _load_profile(user_id: str, enc) -> dict | None:
     """Load a user profile, decrypting if necessary."""
     # Try encrypted first
@@ -124,14 +135,22 @@ async def get_user_profile(user_id: str = "default"):
 
 @router.get("/settings/notifications")
 async def get_notification_settings():
-    """Return current SMS/Text notification settings."""
-    return notifications.get_settings()
+    """Return current SMS/Text notification settings with masked password."""
+    settings = notifications.get_settings()
+    return _mask_notification_settings(settings)
 
 @router.post("/settings/notifications")
 async def update_notification_settings(settings: dict):
-    """Update phone, carrier, and enable/disable status."""
+    """Update notification settings, preserving existing password if masked."""
+    incoming_pass = settings.get("smtp_pass")
+    # Detect if the password was passed back in its masked form.
+    if isinstance(incoming_pass, str) and incoming_pass.startswith("****"):
+        current = notifications.get_settings()
+        if current.get("smtp_pass"):
+            settings["smtp_pass"] = current["smtp_pass"]
     notifications.save_settings(settings)
-    return {"status": "ok", "settings": settings}
+    # Security: Ensure the response also contains masked settings to prevent leak.
+    return {"status": "ok", "settings": _mask_notification_settings(settings)}
 
 @router.get("/settings/cloud")
 async def get_cloud_settings():

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import patch
+from backend.routes import settings
+from backend import notifications
+
+@pytest.fixture
+def mock_settings_file(tmp_path):
+    mock_path = tmp_path / "notification_settings.json"
+    with patch("backend.notifications.SETTINGS_FILE", mock_path):
+        yield mock_path
+
+@pytest.mark.asyncio
+async def test_get_notification_settings_masks_password(mock_settings_file):
+    secret = "my_secret_password_123"
+    notifications.save_settings({
+        "enabled": True,
+        "smtp_pass": secret
+    })
+
+    resp = await settings.get_notification_settings()
+    assert resp["smtp_pass"].startswith("****")
+    assert resp["smtp_pass"] != secret
+    assert resp["smtp_pass"].endswith("_123")
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_preserves_masked_password(mock_settings_file):
+    secret = "my_secret_password_123"
+    notifications.save_settings({
+        "enabled": True,
+        "smtp_pass": secret
+    })
+
+    # Get the masked password
+    resp_get = await settings.get_notification_settings()
+    masked_pw = resp_get["smtp_pass"]
+
+    # Update other fields but pass back masked password
+    update_data = {
+        "enabled": False,
+        "smtp_pass": masked_pw
+    }
+    resp_post = await settings.update_notification_settings(update_data)
+
+    # Verify original secret is still in the real settings
+    saved = notifications.get_settings()
+    assert saved["smtp_pass"] == secret
+    assert saved["enabled"] is False
+
+    # NEW: Verify that the POST response itself was masked
+    assert "settings" in resp_post
+    assert resp_post["settings"]["smtp_pass"].startswith("****")
+    assert resp_post["settings"]["smtp_pass"] != secret
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_handles_none_password(mock_settings_file):
+    notifications.save_settings({
+        "enabled": True,
+        "smtp_pass": "some_pass"
+    })
+
+    update_data = {
+        "enabled": False,
+        "smtp_pass": None
+    }
+    # This should not crash
+    resp = await settings.update_notification_settings(update_data)
+    assert resp["status"] == "ok"
+
+    saved = notifications.get_settings()
+    assert saved["smtp_pass"] is None
+    assert saved["enabled"] is False
+
+@pytest.mark.asyncio
+async def test_update_notification_settings_allows_new_password(mock_settings_file):
+    notifications.save_settings({
+        "enabled": True,
+        "smtp_pass": "old_pass"
+    })
+
+    new_secret = "brand_new_password"
+    update_data = {
+        "enabled": True,
+        "smtp_pass": new_secret
+    }
+    await settings.update_notification_settings(update_data)
+
+    saved = notifications.get_settings()
+    assert saved["smtp_pass"] == new_secret


### PR DESCRIPTION
Identified a security vulnerability where SMTP passwords were being exposed in plain text via the notification settings API. Implemented masking in both GET and POST responses and added round-trip preservation logic to ensure configuration isn't broken when users save settings without changing the password. Verified with new unit tests and multiple secret lengths.

---
*PR created automatically by Jules for task [1946201160451273127](https://jules.google.com/task/1946201160451273127) started by @SamDeiter*