### PR TITLE
⚡ Bolt: Implement shared AsyncClient singleton for connection pooling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-05-15 - Non-blocking System Metrics in FastAPI
 **Learning:** Using `psutil.cpu_percent(interval=0.1)` in an async FastAPI route blocks the entire event loop for 100ms. This significantly increases latency for all concurrent requests.
 **Action:** Always prime `psutil.cpu_percent(interval=None)` at module load or startup and use `interval=None` in async handlers to retrieve metrics instantly without blocking.
+## 2025-05-22 - Shared AsyncClient for Connection Pooling
+**Learning:** Instantiating a new `httpx.AsyncClient` for every LLM request or health check adds significant overhead due to repeated TCP/TLS handshakes. A shared singleton enables connection pooling, reducing latency. However, when refactoring, it's critical to: 1) maintain per-request timeouts (shared clients may have different defaults), and 2) meticulously check indentation when removing `async with` blocks to avoid syntax errors.
+**Action:** Use `backend.utils.http_client.get_async_client()` for all HTTP requests and ensure the client is closed in the application lifespan.

--- a/backend/logic/llm_client.py
+++ b/backend/logic/llm_client.py
@@ -4,6 +4,7 @@ import httpx
 import asyncio
 from typing import Optional, List, Dict, Any, AsyncIterator
 from backend import config, gemini_client
+from backend.utils.http_client import get_async_client
 
 logger = logging.getLogger("localmind.logic.llm_client")
 
@@ -57,48 +58,49 @@ class LLMClient:
 
         logger.info(f"Ollama request: model={payload.get('model')}, messages={len(payload.get('messages',[]))}, keys={list(payload.keys())}")
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            for attempt in range(max_retries):
-                try:
-                    async with client.stream("POST", url, json=payload, timeout=self.timeout) as response:
-                        if response.status_code != 200:
-                            err = await response.aread()
-                            logger.error(f"Ollama stream error: {err.decode()}")
-                            yield {"error": f"Ollama error {response.status_code}"}
-                            return
+        client = get_async_client()
+        for attempt in range(max_retries):
+            try:
+                # ⚡ Bolt: Use the shared AsyncClient singleton for connection pooling
+                async with client.stream("POST", url, json=payload, timeout=self.timeout) as response:
+                    if response.status_code != 200:
+                        err = await response.aread()
+                        logger.error(f"Ollama stream error: {err.decode()}")
+                        yield {"error": f"Ollama error {response.status_code}"}
+                        return
 
-                        line_count = 0
-                        async for line in response.aiter_lines():
-                            if not line:
-                                continue
-                            line_count += 1
-                            try:
-                                data = json.loads(line)
-                                token = ""
-                                if "message" in data:
-                                    token = data["message"].get("content", "")
-                                elif "response" in data:
-                                    token = data.get("response", "")
+                    line_count = 0
+                    async for line in response.aiter_lines():
+                        if not line:
+                            continue
+                        line_count += 1
+                        try:
+                            data = json.loads(line)
+                            token = ""
+                            if "message" in data:
+                                token = data["message"].get("content", "")
+                            elif "response" in data:
+                                token = data.get("response", "")
 
-                                yield {
-                                    "token": token,
-                                    "done": data.get("done", False),
-                                    "tool_calls": data.get("message", {}).get("tool_calls", []),
-                                }
-                            except json.JSONDecodeError:
-                                logger.warning(f"Failed to decode JSON: {line[:100]}")
-                                continue
-                    logger.info(f"Ollama stream completed: {line_count} lines received")
-                    return
+                            yield {
+                                "token": token,
+                                "done": data.get("done", False),
+                                "tool_calls": data.get("message", {}).get("tool_calls", []),
+                            }
+                        except json.JSONDecodeError:
+                            logger.warning(f"Failed to decode JSON: {line[:100]}")
+                            continue
+                logger.info(f"Ollama stream completed: {line_count} lines received")
+                return
 
-                except Exception as e:
-                    if attempt < max_retries - 1:
-                        wait_time = backoff_factor * (2 ** attempt)
-                        logger.warning(f"Ollama attempt {attempt+1} failed: {e}. Retrying in {wait_time}s...")
-                        await asyncio.sleep(wait_time)
-                    else:
-                        logger.error(f"Ollama stream failed after {max_retries} attempts: {e}")
-                        yield {"error": str(e)}
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    wait_time = backoff_factor * (2 ** attempt)
+                    logger.warning(f"Ollama attempt {attempt+1} failed: {e}. Retrying in {wait_time}s...")
+                    await asyncio.sleep(wait_time)
+                else:
+                    logger.error(f"Ollama stream failed after {max_retries} attempts: {e}")
+                    yield {"error": str(e)}
 
     async def _stream_gemini(
         self, model: str, messages: List[Dict[str, str]], **kwargs
@@ -137,13 +139,14 @@ class LLMClient:
             payload["options"] = kwargs.pop("options")
         payload.update(kwargs)
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            try:
-                r = await client.post(url, json=payload)
-                data = r.json()
-                return {
-                    "content": data.get("message", {}).get("content", ""),
-                    "tool_calls": data.get("message", {}).get("tool_calls", []),
-                }
-            except Exception as e:
-                return {"error": str(e)}
+        # ⚡ Bolt: Use the shared AsyncClient singleton for connection pooling
+        client = get_async_client()
+        try:
+            r = await client.post(url, json=payload, timeout=self.timeout)
+            data = r.json()
+            return {
+                "content": data.get("message", {}).get("content", ""),
+                "tool_calls": data.get("message", {}).get("tool_calls", []),
+            }
+        except Exception as e:
+            return {"error": str(e)}

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from fastapi import APIRouter
 from backend.config import OLLAMA_BASE_URL
 from backend.db import DB_PATH
+from backend.utils.http_client import get_async_client
 
 try:
     import psutil
@@ -85,9 +86,10 @@ async def health_check():
     """Check server and Ollama connectivity with enhanced system metrics."""
     # Ollama status
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=2.0)
-            ollama_ok = resp.status_code == 200
+        # ⚡ Bolt: Use the shared AsyncClient singleton for connection pooling
+        client = get_async_client()
+        resp = await client.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=2.0)
+        ollama_ok = resp.status_code == 200
     except Exception:
         ollama_ok = False
 
@@ -148,16 +150,17 @@ async def hardware_status():
 
     models = []
     try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            r = await client.get(f"{OLLAMA_BASE_URL}/api/ps")
-            data = r.json()
-            for m in data.get("models", []):
-                models.append({
-                    "name": m.get("name", "unknown"),
-                    "size_gb": round(m.get("size", 0) / (1024**3), 1),
-                    "vram_gb": round(m.get("size_vram", 0) / (1024**3), 1),
-                    "processor": m.get("details", {}).get("quantization_level", ""),
-                })
+        # ⚡ Bolt: Use the shared AsyncClient singleton for connection pooling
+        client = get_async_client()
+        r = await client.get(f"{OLLAMA_BASE_URL}/api/ps", timeout=2.0)
+        data = r.json()
+        for m in data.get("models", []):
+            models.append({
+                "name": m.get("name", "unknown"),
+                "size_gb": round(m.get("size", 0) / (1024**3), 1),
+                "vram_gb": round(m.get("size_vram", 0) / (1024**3), 1),
+                "processor": m.get("details", {}).get("quantization_level", ""),
+            })
     except Exception:
         pass
 
@@ -167,14 +170,15 @@ async def hardware_status():
 async def list_models():
     """List available Ollama models."""
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=3.0)
-            data = resp.json()
-            models = [
-                {"name": m["name"], "size": m.get("size", 0)}
-                for m in data.get("models", [])
-            ]
-            return {"models": models}
+        # ⚡ Bolt: Use the shared AsyncClient singleton for connection pooling
+        client = get_async_client()
+        resp = await client.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=3.0)
+        data = resp.json()
+        models = [
+            {"name": m["name"], "size": m.get("size", 0)}
+            for m in data.get("models", [])
+        ]
+        return {"models": models}
     except Exception as e:
         return {"models": [], "error": str(e)}
 
@@ -202,9 +206,10 @@ async def health_ready():
     # Ollama check
     ollama_ok = False
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=2.0)
-            ollama_ok = resp.status_code == 200
+        # ⚡ Bolt: Use the shared AsyncClient singleton for connection pooling
+        client = get_async_client()
+        resp = await client.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=2.0)
+        ollama_ok = resp.status_code == 200
         checks["ollama"] = "pass" if ollama_ok else "fail"
     except Exception:
         checks["ollama"] = "fail"

--- a/backend/server.py
+++ b/backend/server.py
@@ -29,6 +29,7 @@ from backend.tools.registry import ToolRegistry
 from backend.metacognition.controller import MetaCognitiveController
 from backend import notifications, gemini_client, db
 from backend.db import DB_PATH, get_db
+from backend.utils.http_client import close_async_client
 from backend.core.schema import init_phase0_schema, ensure_default_tenant
 from backend.core.telemetry import (
     init_telemetry_schema, health_checker, metrics_collector, alert_manager,
@@ -230,6 +231,7 @@ async def lifespan(app: FastAPI):
         await gc_worker.stop()
     if slack_bot:
         await slack_bot.stop()
+    await close_async_client()
 
 def _configure_routers():
     """Inject dependencies into route modules to avoid circular imports."""

--- a/backend/utils/http_client.py
+++ b/backend/utils/http_client.py
@@ -1,0 +1,33 @@
+import httpx
+import logging
+from typing import Optional
+
+logger = logging.getLogger("localmind.utils.http_client")
+
+# Global client singleton
+_async_client: Optional[httpx.AsyncClient] = None
+
+def get_async_client() -> httpx.AsyncClient:
+    """Return the shared httpx.AsyncClient singleton, creating it if necessary.
+
+    Using a shared client enables connection pooling, which significantly reduces
+    the overhead of frequent API calls (e.g., to Ollama or external search).
+    """
+    global _async_client
+    if _async_client is None:
+        # ⚡ Bolt: Configure connection pooling and long timeouts for LLM stability
+        _async_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(120.0, connect=10.0),
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+            follow_redirects=True
+        )
+        logger.info("Shared AsyncClient singleton initialized (pooling enabled)")
+    return _async_client
+
+async def close_async_client():
+    """Close the shared AsyncClient singleton during application shutdown."""
+    global _async_client
+    if _async_client is not None:
+        await _async_client.aclose()
+        _async_client = None
+        logger.info("Shared AsyncClient singleton closed")

--- a/tests/test_bolt_http.py
+++ b/tests/test_bolt_http.py
@@ -1,0 +1,23 @@
+import pytest
+import httpx
+from backend.utils.http_client import get_async_client, close_async_client
+
+@pytest.mark.asyncio
+async def test_shared_client_singleton():
+    client1 = get_async_client()
+    client2 = get_async_client()
+    assert client1 is client2
+    assert isinstance(client1, httpx.AsyncClient)
+    assert not client1.is_closed
+
+@pytest.mark.asyncio
+async def test_shared_client_close():
+    client = get_async_client()
+    await close_async_client()
+    assert client.is_closed
+
+    # Getting a new client after close should work and return a new open client
+    client3 = get_async_client()
+    assert client3 is not client
+    assert not client3.is_closed
+    await close_async_client()


### PR DESCRIPTION
### 💡 What: The optimization implemented
Implemented a shared `httpx.AsyncClient` singleton in `backend/utils/http_client.py` and refactored the backend to use it instead of creating local client instances for every request.

### 🎯 Why: The performance problem it solves
Creating a new `AsyncClient` for every LLM generation or system health check (which happens frequently) incurs significant overhead due to the repeated setup and teardown of TCP and TLS connections. This is especially impactful when communicating with a local Ollama instance or external APIs.

### 📊 Impact: Expected performance improvement
- **Reduces latency** for frequent small requests (like health checks) by eliminating handshake overhead.
- **Improved resource efficiency** through connection reuse (pooling), reducing the number of open sockets and file descriptors.
- **LLM Stability:** Consistent 120s timeout and optimized connection limits (100 max, 20 keepalive).

### 🔬 Measurement: How to verify the improvement
1. Run `python3 -m pytest tests/test_bolt_http.py` to verify singleton and lifecycle logic.
2. Observe backend logs for "Shared AsyncClient singleton initialized" during startup.
3. System routes (`/api/health`, `/api/hardware`) and Chat turns will now benefit from pooled connections to Ollama.

---
*PR created automatically by Jules for task [8447996771851004263](https://jules.google.com/task/8447996771851004263) started by @SamDeiter*