### PR TITLE
🛡️ Sentinel: Harden path-based security in Auth and RBAC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - Path Traversal bypass in Auth/RBAC Middleware
+**Vulnerability:** Authentication and RBAC checks using `startswith()` on raw request URLs are vulnerable to path traversal (e.g., `/health/../api/secret`) and prefix collisions (e.g., `/api_secret` matching `/api`).
+**Learning:** Raw `request.url.path` must be normalized using `posixpath.normpath()` before any security checks. Furthermore, `PurePosixPath.is_relative_to()` should be used instead of string `startswith()` to ensure matches occur at path segment boundaries.
+**Prevention:** Always normalize incoming URL paths and use component-aware path libraries for prefix validation.

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -17,6 +17,8 @@ by the auth layer, so RBAC never blocks a fresh install.
 from __future__ import annotations
 
 import logging
+import posixpath
+from pathlib import PurePosixPath
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
@@ -75,8 +77,11 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     """Return ``True`` if *role* may perform *method* on *path*."""
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
+    # Normalize path to prevent bypasses
+    norm_path = posixpath.normpath(path)
+    pure_path = PurePosixPath(norm_path)
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        if pure_path.is_relative_to(allowed_prefix):
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/backend/server.py
+++ b/backend/server.py
@@ -10,8 +10,9 @@ Constants live in backend/config.py.
 """
 
 import logging
+import posixpath
 from contextlib import asynccontextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -288,14 +289,16 @@ async def auth_middleware(request: Request, call_next):
     the system is in bootstrap mode with no keys).
     """
     from fastapi.responses import JSONResponse as _JSONResponse
-    path = request.url.path
+    # Normalize path to prevent traversal bypasses like /health/../api/
+    path = posixpath.normpath(request.url.path)
+    pure_path = PurePosixPath(path)
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    if path in _AUTH_SKIP_EXACT or any(pure_path.is_relative_to(p) for p in _AUTH_SKIP_PREFIXES):
         return await call_next(request)
 
-    # Only enforce auth on /api/ routes
-    if path.startswith("/api/"):
+    # Only enforce auth on /api routes
+    if pure_path.is_relative_to("/api"):
         try:
             from backend.security.auth import authenticate_request
             from backend.security.rbac import check_permission


### PR DESCRIPTION
Fixed a security vulnerability where path traversal (e.g., `/health/../api/secret`) and prefix collisions could be used to bypass authentication or RBAC checks. The fix involves normalizing request paths and using `PurePosixPath.is_relative_to` for robust, component-aware path matching.

---
*PR created automatically by Jules for task [5221385574925922550](https://jules.google.com/task/5221385574925922550) started by @SamDeiter*