### PR TITLE
🛡️ Sentinel: [HIGH] Fix TerminalTool command obfuscation bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-06-18 - Command Injection bypass via Character Obfuscation
+**Vulnerability:** Regex-based command blocklists using word boundaries (\b) can be bypassed by inserting shell escape characters like backslashes (\), quotes (' or "), or line continuations (\\n) within the command name (e.g., r\m, r''m).
+**Learning:** Shells normalize these characters before execution, but static regex checks do not.
+**Prevention:** Normalize the command string by stripping quotes and backslashes before running it through the security regex. Perform this normalization BEFORE splitting the command string by shell operators to catch bypasses like r\\nm.

--- a/backend/tools/terminal.py
+++ b/backend/tools/terminal.py
@@ -45,14 +45,33 @@ class TerminalTool(BaseTool):
             "required": ["command"]
         }
 
+    @staticmethod
+    def _normalize(command: str) -> str:
+        """Strip shell escapes and quotes that bypass pattern detection."""
+        # Remove line continuations (backslash followed by newline)
+        c = re.sub(r"\\\n", "", command)
+        # Remove backslashes
+        c = re.sub(r"\\", "", c)
+        # Remove quotes
+        c = re.sub(r"['\"]", "", c)
+        return c
+
     async def execute(self, **kwargs) -> dict[str, Any]:
         command = kwargs.get("command", "")
         timeout = kwargs.get("timeout", 10)
         
         # Security: Multi-stage check for dangerous patterns and shell chaining.
-        # We split by operators to check EACH command in a chain.
-        commands_to_check = SHELL_OPERATORS.split(command)
-        is_dangerous = any(DANGEROUS_PATTERN.search(cmd) for cmd in commands_to_check)
+
+        # 1. Normalize the entire command to strip escapes/quotes that bypass detection.
+        # We do this BEFORE splitting by operators to handle line continuations correctly.
+        normalized_command = self._normalize(command)
+
+        # 2. Split by operators to check EACH command in a chain.
+        commands_to_check = SHELL_OPERATORS.split(normalized_command)
+
+        is_dangerous = any(
+            DANGEROUS_PATTERN.search(cmd) for cmd in commands_to_check
+        )
 
         if is_dangerous:
             proposer = ProposeActionTool()

--- a/tests/test_terminal_security.py
+++ b/tests/test_terminal_security.py
@@ -68,3 +68,38 @@ async def test_terminal_tool_bypass_attempt():
             assert result["success"] is True
             # Proposer should NOT have been called
             assert MockProposer.call_count == 0
+
+@pytest.mark.asyncio
+async def test_terminal_tool_bypass_normalization():
+    tool = TerminalTool()
+
+    # Mock ProposeActionTool
+    with patch("backend.tools.terminal.ProposeActionTool") as MockProposer:
+        mock_proposer_instance = MockProposer.return_value
+        mock_proposer_instance.execute = AsyncMock(return_value={"approved": False})
+
+        # Test backslash bypass
+        result = await tool.execute(command="r\\m -rf /")
+        assert result["success"] is False
+        assert "User denied execution" in result["error"]
+
+        # Test single quote bypass
+        result = await tool.execute(command="r''m -rf /")
+        assert result["success"] is False
+        assert "User denied execution" in result["error"]
+
+        # Test double quote bypass
+        result = await tool.execute(command='r""m -rf /')
+        assert result["success"] is False
+        assert "User denied execution" in result["error"]
+
+        # Test line continuation bypass
+        # Note: in Python strings, we need to escape the backslash
+        result = await tool.execute(command="r\\\nm -rf /")
+        assert result["success"] is False
+        assert "User denied execution" in result["error"]
+
+        # Test combined bypass
+        result = await tool.execute(command="r'\"\\m -rf /")
+        assert result["success"] is False
+        assert "User denied execution" in result["error"]


### PR DESCRIPTION
The `TerminalTool` used a regex-based blocklist with word boundaries to identify dangerous commands. However, shell commands can be obfuscated using backslashes, quotes, or line continuations (e.g., `r\m`, `r''m`, `r\
m`) which bypass simple regex matching while still executing the dangerous command.

This PR introduces a normalization step that strips these obfuscation characters before the security check.

**Changes:**
1.  **Normalization:** Added `_normalize` static method to `TerminalTool` in `backend/tools/terminal.py` to remove `\`, `'`, `"`, and `\\\n`.
2.  **Order of Operations:** The command is now normalized *before* being split by shell operators, ensuring that multi-line commands or chained commands are correctly evaluated.
3.  **Tests:** Expanded `tests/test_terminal_security.py` with new test cases covering various obfuscation techniques.

**Verification:**
- Ran `python3 -m pytest tests/test_terminal_security.py` (All 4 tests passed).
- Verified manually with a reproduction script covering backslash, single/double quotes, and line continuation bypasses.


---
*PR created automatically by Jules for task [16452517001467861470](https://jules.google.com/task/16452517001467861470) started by @SamDeiter*