### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Prefix Bypass in RBAC and PromptGuard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - RBAC Route Prefix Bypass
+**Vulnerability:** Using `path.startswith(allowed_prefix)` for RBAC allows accessing unauthorized sibling routes. For example, if `/api/chat` is allowed, `/api/chat_admin` also passes the check.
+**Learning:** String prefix checks do not respect logical URL or path boundaries.
+**Prevention:** Ensure the match is either exact (`path == allowed_prefix`) or that the prefix is followed by a path separator (`path.startswith(allowed_prefix.rstrip("/") + "/")`).

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -30,8 +30,19 @@ try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
     def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
-        """Fallback: resolve without jail check."""
-        return Path(path).resolve()
+        """Fallback: resolve with directory-boundary aware prefix check."""
+        resolved_base = Path(base).resolve()
+        resolved_path = (resolved_base / str(path)).resolve()
+
+        # Security: Use is_relative_to (Python 3.9+) to ensure path is inside base.
+        # Fallback to string prefix check with trailing separator for older Pythons.
+        try:
+            resolved_path.relative_to(resolved_base)
+        except ValueError:
+            logger.warning("Path escape attempt in fallback safe_resolve: %r", path)
+            raise ValueError(f"Path escapes jail: {path}")
+
+        return resolved_path
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -488,7 +499,11 @@ class PromptGuard:
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
                         resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        # Redundant security check: Ensure the resolved path is strictly within job_dir.
+                        # safe_resolve in backend.security.paths already does this, but we reinforce it here.
+                        try:
+                            resolved.relative_to(job_dir.resolve())
+                        except ValueError:
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,9 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Security: Ensure the path matches the allowed prefix exactly OR as a
+        # parent directory (e.g. /api/chat matches /api/chat/send but NOT /api/chat_admin).
+        if path == allowed_prefix or path.startswith(allowed_prefix.rstrip("/") + "/"):
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/tests/verify_sentinel_fix.py
+++ b/tests/verify_sentinel_fix.py
@@ -1,0 +1,54 @@
+import pytest
+from pathlib import Path
+from backend.security.rbac import _is_allowed
+from backend.security.prompt_guard import PromptGuard
+
+def test_rbac_prefix_bypass():
+    # operator is allowed GET on /api/
+    assert _is_allowed("operator", "GET", "/api/jobs") is True
+    assert _is_allowed("operator", "GET", "/api/chat") is True
+
+    # operator is allowed POST on /api/chat
+    assert _is_allowed("operator", "POST", "/api/chat") is True
+    assert _is_allowed("operator", "POST", "/api/chat/send") is True
+
+    # SECURITY BYPASS TEST: /api/chat_admin should NOT be allowed if only /api/chat is allowed
+    # (assuming /api/chat_admin is not in the allowed list)
+    assert _is_allowed("operator", "POST", "/api/chat_admin") is False
+    assert _is_allowed("operator", "POST", "/api/chat-service") is False
+
+def test_prompt_guard_path_jailing_bypass(tmp_path):
+    guard = PromptGuard("strict")
+    job_dir = tmp_path / "job_1"
+    job_dir.mkdir()
+
+    evil_job_dir = tmp_path / "job_10"
+    evil_job_dir.mkdir()
+    evil_file = evil_job_dir / "secret.txt"
+    evil_file.write_text("evil")
+
+    # tool call with path escaping via prefix bypass
+    call = {
+        "name": "read_file",
+        "args": {"path": str(evil_file)}
+    }
+
+    # The check should catch that /tmp/job_10 is not in /tmp/job_1
+    result = guard.validate_tool_call(call, ["read_file"], job_dir)
+    assert result.valid is False
+    assert any("escapes job directory" in issue for issue in result.issues)
+
+def test_prompt_guard_relative_to_logic(tmp_path):
+    # Test the logic I added to validate_tool_call
+    # Using relative_to ensures that /tmp/job_10 is not considered inside /tmp/job_1
+    # even if it starts with the same string prefix.
+
+    job_dir = Path("/tmp/job_1")
+    evil_path = Path("/tmp/job_10/secret.txt")
+
+    # Prefix check would pass
+    assert str(evil_path).startswith(str(job_dir)) is True
+
+    # relative_to check should fail
+    with pytest.raises(ValueError):
+        evil_path.relative_to(job_dir)


### PR DESCRIPTION
This PR fixes a high-severity partial string prefix matching vulnerability in the RBAC and PromptGuard modules. 

Previously, `backend/security/rbac.py` used `path.startswith(allowed_prefix)`, which meant that a user allowed to access `/api/chat` could also access `/api/chat_admin` if it existed. I've updated this to ensure matches only occur on exact equality or at directory boundaries.

Similarly, `backend/security/prompt_guard.py` used string prefix checking for path jailing, which was vulnerable to bypasses like `/tmp/job_10` being allowed when jailed to `/tmp/job_1`. I've updated the validation logic and the fallback `safe_resolve` implementation to use `Path.relative_to()`, which correctly respects path segments.

A new test suite `tests/verify_sentinel_fix.py` has been added to verify these fixes and prevent regressions.

---
*PR created automatically by Jules for task [5753530973639828605](https://jules.google.com/task/5753530973639828605) started by @SamDeiter*