### PR TITLE
🛡️ Sentinel: Harden RunCodeTool sandbox against RCE

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2026-05-14 - Python Sandbox Escape via dynamic attribute access and broad imports
+**Vulnerability:** Simple blocklists for `os.remove` or specific dangerous functions are insufficient to prevent arbitrary code execution in a Python sandbox. Attackers can use `getattr(os, 'system')` or `__import__('os').system('...')` to bypass static string checks.
+**Learning:** Python's dynamic nature allows accessing restricted functionality through multiple indirect methods. A security blocklist must include fundamental primitives like `getattr` and `__import__` if they are not strictly required.
+**Prevention:** Harden sandbox blocklists by including `getattr`, `__import__`, and all process execution entry points (`os.system`, `subprocess.*`, `pty.spawn`). For robust security, prefer AST-based analysis or containerized isolation over regex blocklists.

--- a/backend/tools/run_code.py
+++ b/backend/tools/run_code.py
@@ -29,9 +29,13 @@ BLOCKLIST_PATTERNS = [
     r"\bsubprocess\b.*\brmdir\b",
     r"\bsubprocess\b.*\bformat\b",
     r"\bsend2trash\b",
-    r"\b__import__\s*\(\s*['\"]os['\"]\s*\)\s*\.remove\b",
+    r"\b__import__\b",
     r"\bexec\s*\(",
     r"\beval\s*\(",
+    r"\bgetattr\b",
+    r"\bos\.(system|popen|spawn[a-z]*|posix_spawn[a-z]*)\b",
+    r"\bsubprocess\.(run|call|check_call|check_output|Popen)\b",
+    r"\bpty\.spawn\b",
 ]
 
 
@@ -40,7 +44,7 @@ def _safety_check(code: str) -> str | None:
     for pattern in BLOCKLIST_PATTERNS:
         match = re.search(pattern, code, re.IGNORECASE)
         if match:
-            return f"BLOCKED: Code contains dangerous operation: '{match.group()}'. LocalMind cannot delete files."
+            return f"BLOCKED: Code contains dangerous operation: '{match.group()}'. LocalMind cannot execute potentially dangerous operations for security reasons."
     return None
 
 


### PR DESCRIPTION
Identified a high-priority security risk where the `RunCodeTool` sandbox could be easily bypassed using standard Python dynamic attribute access (`getattr`) or broad imports (`__import__`). 

The previous blocklist was only targeting a few specific destructive operations (like `os.remove`), but didn't prevent general remote code execution (RCE) via `os.system` or `subprocess`.

This PR hardens the `RunCodeTool` by adding these common RCE vectors to the pre-execution safety check.

### 🛡️ Sentinel Assessment:
- 🚨 Severity: HIGH
- 💡 Vulnerability: Sandbox bypass / RCE
- 🎯 Impact: An attacker (or a rogue agent) could execute arbitrary shell commands on the host system.
- 🔧 Fix: Expanded the regex-based blocklist to cover dynamic access and shell execution primitives.
- ✅ Verification: Verified with a reproduction script that attempted to use `os.system`, `getattr(os, 'system')`, and `subprocess.run`. All are now successfully blocked.

---
*PR created automatically by Jules for task [3209615949728884997](https://jules.google.com/task/3209615949728884997) started by @SamDeiter*