### PR TITLE
🛡️ Sentinel: Fix RBAC Path Prefix Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-14 - RBAC Path Prefix Bypass
+**Vulnerability:** Simple string-based prefix matching for RBAC paths (e.g., `path.startswith(allowed_prefix)`) allows unauthorized access to endpoints that share a common prefix. For example, an operator with access to `/api/chat` could also access `/api/chat_admin` because it also starts with `/api/chat`.
+**Learning:** Prefix checks must be segment-aware to respect logical URI boundaries and prevent accidental authorization of sensitive adjacent routes.
+**Prevention:** Use segment-aware path comparison: `path == allowed_prefix or path.startswith(allowed_prefix.rstrip("/") + "/")`. This ensures only exact matches or true sub-paths are permitted.

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,13 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Security: Use segment-aware prefix matching to prevent prefix bypasses
+        # (e.g., /api/chat matching /api/chat_admin).
+        is_path_match = (
+            path == allowed_prefix or
+            path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_path_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False


### PR DESCRIPTION
### 🚨 Severity: HIGH
### 💡 Vulnerability: RBAC Path Prefix Bypass
The application used `path.startswith(allowed_prefix)` to validate if a user had permission to access a specific API route. This is vulnerable to prefix bypasses where a user with permission for a generic route (e.g., `/api/chat`) could access a more sensitive route starting with the same characters (e.g., `/api/chat_admin`).

### 🎯 Impact
An attacker with limited privileges (e.g., 'operator' role) could potentially access administrative or sensitive endpoints that they should not have access to, provided the sensitive endpoint's path starts with a prefix they are already authorized for.

### 🔧 Fix
Updated `backend/security/rbac.py` to use segment-aware path matching:
```python
is_path_match = (
    path == allowed_prefix or
    path.startswith(allowed_prefix.rstrip("/") + "/")
)
```
This ensures that `/api/chat` matches `/api/chat/123` but NOT `/api/chat_admin`.

### ✅ Verification
1. Created a reproduction script `repro_rbac.py` that tested various path combinations against the 'operator' role.
2. Verified that before the fix, `/api/chat_admin` was allowed.
3. Verified that after the fix, `/api/chat_admin` is blocked while `/api/chat` and `/api/chat/123` remain allowed.
4. Ran existing RBAC tests in `tests/test_auth_rbac.py` and they passed.

---
*PR created automatically by Jules for task [15381004368306170992](https://jules.google.com/task/15381004368306170992) started by @SamDeiter*