### PR TITLE
🛡️ Sentinel: Fix RBAC prefix bypass and PromptGuard path jailing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,13 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-06-14 - RBAC Prefix Bypass via `startswith()`
+**Vulnerability:** Role-based access control using `path.startswith(allowed_prefix)` allows bypassing intended restrictions if one prefix is a substring of another (e.g., `/api/chat` matching `/api/chat_admin`).
+**Learning:** String prefix checks do not account for path segment boundaries.
+**Prevention:** Use segment-aware matching by checking for an exact match OR ensuring the prefix is followed by a path separator (e.g., `path == prefix or path.startswith(prefix.rstrip("/") + "/")`).
+
+## 2024-06-14 - Broken Path Jailing Logic in PromptGuard
+**Vulnerability:** `PromptGuard.validate_tool_call` used swapped arguments for `safe_resolve(arg_value, job_dir)`, causing it to attempt jailing the sandbox directory inside the user-provided (potentially malicious) path. It also relied on a manual `startswith` re-check which is prone to string-prefix bypasses.
+**Learning:** Security utilities must be called with correct parameter ordering, and internal jailing logic should be centralized in a single robust function (like `safe_resolve`) rather than duplicated with weaker checks.
+**Prevention:** Standardize on `safe_resolve(base_dir, user_path)` and block absolute paths early if only relative paths are expected in a sandboxed context.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import math
+import os
 import re
 import unicodedata
 from dataclasses import dataclass, field
@@ -486,20 +487,18 @@ class PromptGuard:
                 # Path jailing
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
-                    try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                    if os.path.isabs(arg_value):
+                        issues.append(f"Arg '{arg_name}' must be a relative path: {arg_value}")
+                        logger.warning("Blocked absolute path in tool arg %s.%s: %r", tool_name, arg_name, arg_value)
+                    else:
+                        try:
+                            # Correct argument order: (base_dir, user_path)
+                            # safe_resolve already performs internal jail validation.
+                            safe_resolve(job_dir, arg_value)
+                        except Exception as exc:
                             issues.append(
-                                f"Arg '{arg_name}' escapes job directory: {resolved}"
+                                f"Arg '{arg_name}' path resolution failed: {exc}"
                             )
-                            logger.warning(
-                                "Path escape attempt in tool arg %s.%s: %r -> %s",
-                                tool_name, arg_name, arg_value, resolved,
-                            )
-                    except Exception as exc:
-                        issues.append(
-                            f"Arg '{arg_name}' path resolution failed: {exc}"
-                        )
 
         valid = len(issues) == 0
         return ValidationResult(valid=valid, cleaned_text="", issues=issues)

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -72,11 +72,20 @@ ROLE_PERMISSIONS: dict[str, list[tuple[str, str]]] = {
 
 
 def _is_allowed(role: str, method: str, path: str) -> bool:
-    """Return ``True`` if *role* may perform *method* on *path*."""
+    """Return ``True`` if *role* may perform *method* on *path*.
+
+    Uses segment-aware prefix matching to prevent bypasses (e.g. /api/chat
+    matching /api/chat_admin).
+    """
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Segment-aware check: path must be exact match or have prefix + "/"
+        is_path_match = (
+            path == allowed_prefix or
+            path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_path_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False


### PR DESCRIPTION
This PR fixes two critical security vulnerabilities identified during a security scan:

1. **RBAC Prefix Bypass**: The `_is_allowed` function in `backend/security/rbac.py` used a simple `startswith()` check for path-based permissions. This allowed a user with access to `/api/chat` to also access `/api/chat_admin`. I've updated it to use segment-aware matching (`path == prefix or path.startswith(prefix + "/")`).

2. **PromptGuard Path Jailing Logic**: The `validate_tool_call` method in `backend/security/prompt_guard.py` had two major issues:
    - It called `safe_resolve(arg_value, job_dir)` instead of `safe_resolve(job_dir, arg_value)`, effectively trying to jail the job directory inside the user-provided path.
    - It used a manual `startswith()` check on the resolved path which is vulnerable to prefix bypasses (e.g., `/data/job` matching `/data/job_evil`).
    - I've corrected the argument order, added an explicit check to block absolute paths, and now rely on `safe_resolve`'s built-in robust jailing logic.

Both fixes are concise and follow the project's security standards. Verification was performed using a dedicated reproduction script and existing test suites.

---
*PR created automatically by Jules for task [4805552478097739761](https://jules.google.com/task/4805552478097739761) started by @SamDeiter*