### PR TITLE
🛡️ Sentinel: Fix RBAC and PromptGuard prefix bypass vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - RBAC Prefix Bypass via string matching
+**Vulnerability:** Simple `path.startswith(allowed_prefix)` checks in RBAC allowed users to access unauthorized endpoints that shared a prefix with authorized ones (e.g., `/api/chat` allowed access to `/api/chat_admin`).
+**Learning:** String-based prefix matching is insufficient for hierarchical path structures without enforcing segment boundaries.
+**Prevention:** Use segment-aware path comparison: `path == allowed_prefix or path.startswith(allowed_prefix.rstrip("/") + "/")`.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import math
+import os
 import re
 import unicodedata
 from dataclasses import dataclass, field
@@ -29,7 +30,7 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
+    def safe_resolve(base: Path | str, path: str | Path) -> Path:  # type: ignore[misc]
         """Fallback: resolve without jail check."""
         return Path(path).resolve()
 
@@ -56,6 +57,11 @@ SSRF_PATTERNS: list[str] = [
     r"100\.64\.\d{1,3}\.\d{1,3}",    # shared address space (RFC 6598)
 ]
 _SSRF_RE: list[re.Pattern] = [re.compile(p, re.IGNORECASE) for p in SSRF_PATTERNS]
+
+# Detect a Windows absolute path like C:\ or C:/ anywhere in the string.
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+# Detect a Windows UNC path like \\server\share
+_WIN_UNC_RE = re.compile(r"^[\\/]{2}[^\\/]+[\\/]+[^\\/]+")
 
 # ---------------------------------------------------------------------------
 # Injection patterns (Layer 1 — sanitize_input)
@@ -486,19 +492,38 @@ class PromptGuard:
                 # Path jailing
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
+                    # Defense in Depth: Layered path jailing.
+                    # 1. Block absolute paths (POSIX, Windows drive letters, and UNC).
+                    arg_value_stripped = str(arg_value).strip()
+                    is_absolute = (
+                        os.path.isabs(arg_value_stripped) or
+                        _WIN_DRIVE_RE.match(arg_value_stripped) or
+                        _WIN_UNC_RE.match(arg_value_stripped)
+                    )
+                    if is_absolute:
+                        issues.append(f"Arg '{arg_name}' must be a relative path: {arg_value}")
+                        logger.warning("Absolute path blocked in tool arg %s.%s: %r", tool_name, arg_name, arg_value)
+                        continue
+
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
-                            issues.append(
-                                f"Arg '{arg_name}' escapes job directory: {resolved}"
-                            )
-                            logger.warning(
-                                "Path escape attempt in tool arg %s.%s: %r -> %s",
-                                tool_name, arg_name, arg_value, resolved,
-                            )
+                        # 2. Resolve via safe_resolve (throws SecurityError on jail escape).
+                        resolved = safe_resolve(job_dir, arg_value)
+
+                        # 3. Final safety check: ensure resolved path is strictly within the jail.
+                        # This protects against a missing/permissive safe_resolve fallback.
+                        jail_root = job_dir.resolve()
+                        if not str(resolved).startswith(str(jail_root).rstrip(os.sep) + os.sep):
+                            if resolved != jail_root:
+                                issues.append(f"Arg '{arg_name}' escapes job directory: {resolved}")
+                                logger.warning(
+                                    "Path escape attempt in tool arg %s.%s: %r -> %s",
+                                    tool_name, arg_name, arg_value, resolved,
+                                )
                     except Exception as exc:
-                        issues.append(
-                            f"Arg '{arg_name}' path resolution failed: {exc}"
+                        issues.append(f"Arg '{arg_name}' path resolution failed: {exc}")
+                        logger.warning(
+                            "Path validation failed in tool arg %s.%s: %r -> %s",
+                            tool_name, arg_name, arg_value, exc,
                         )
 
         valid = len(issues) == 0

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,13 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Segment-aware prefix check to avoid /api/chat matching /api/chat_admin
+        # We allow exact match OR match with a trailing slash
+        is_path_match = (
+            path == allowed_prefix or
+            path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_path_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False


### PR DESCRIPTION
Identified and fixed two critical security vulnerabilities related to prefix-based bypasses:

1. **RBAC Prefix Bypass**: The `_is_allowed` function in `backend/security/rbac.py` used a simple `startswith` check, which allowed users with access to a prefix (e.g., `/api/chat`) to access unauthorized endpoints sharing that prefix (e.g., `/api/chat_admin`). I updated this to use a segment-aware check.

2. **PromptGuard Path Jailing Bypass**: 
   - Found that `PromptGuard.validate_tool_call` was calling `safe_resolve` with incorrect argument order.
   - Discovered that it relied on a `startswith` check on the resolved path which was also vulnerable to prefix bypass (e.g., `/app/job` matching `/app/job_evil`).
   - Improved the fix by blocking absolute paths (including Windows drive letters and UNC paths) and implementing a robust, segment-aware safety check on the resolved path.

Verification:
- Created and ran reproduction scripts (`repro_rbac.py` and `repro_bug_v2.py`) confirming both vulnerabilities were present and are now fixed.
- Verified that existing tests in `tests/test_auth_rbac.py` and `tests/test_enterprise_security.py` pass (noting two pre-existing unrelated failures in the latter).
- Cleaned up all temporary reproduction files.

---
*PR created automatically by Jules for task [3553743383114713277](https://jules.google.com/task/3553743383114713277) started by @SamDeiter*