### PR TITLE
🛡️ Sentinel: Harden path and prefix validation against bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-06-25 - RBAC Prefix Bypass via `startswith()`
+**Vulnerability:** Authorization checks using `path.startswith(allowed_prefix)` allow access to endpoints that share a prefix but are distinct, such as `/api/chat_admin` matching an allowed `/api/chat`.
+**Learning:** String prefix matching is insufficient for URI path authorization without considering segment boundaries.
+**Prevention:** Use segment-aware matching: `path == prefix or path.startswith(prefix.rstrip("/") + "/")`. This ensures the match is either exact or against a proper sub-segment.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,9 +29,9 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
+    def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:  # type: ignore[misc]
         """Fallback: resolve without jail check."""
-        return Path(path).resolve()
+        return Path(user_path).resolve()
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -487,18 +487,16 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
-                            issues.append(
-                                f"Arg '{arg_name}' escapes job directory: {resolved}"
-                            )
-                            logger.warning(
-                                "Path escape attempt in tool arg %s.%s: %r -> %s",
-                                tool_name, arg_name, arg_value, resolved,
-                            )
+                        # Correct order: safe_resolve(base_dir, user_path)
+                        # safe_resolve handles jailing and symlink resolution internally.
+                        safe_resolve(job_dir, arg_value)
                     except Exception as exc:
                         issues.append(
-                            f"Arg '{arg_name}' path resolution failed: {exc}"
+                            f"Arg '{arg_name}' path validation failed: {exc}"
+                        )
+                        logger.warning(
+                            "Path validation failed in tool arg %s.%s: %r -> %s",
+                            tool_name, arg_name, arg_value, exc,
                         )
 
         valid = len(issues) == 0

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,8 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Segment-aware prefix check to prevent bypasses like /api/chat_admin matching /api/chat
+        if path == allowed_prefix or path.startswith(allowed_prefix.rstrip("/") + "/"):
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False


### PR DESCRIPTION
I have hardened the RBAC path validation in `backend/security/rbac.py` by implementing segment-aware prefix matching, preventing unauthorized access to endpoints that share string prefixes with allowed ones. Additionally, I refactored `PromptGuard.validate_tool_call` in `backend/security/prompt_guard.py` to correctly integrate with the centralized `safe_resolve` utility, fixing a logic error in argument ordering and removing a vulnerable manual jail check. These changes ensure more robust protection against directory traversal and authorization bypasses.

---
*PR created automatically by Jules for task [9681395319415103337](https://jules.google.com/task/9681395319415103337) started by @SamDeiter*