### PR TITLE
🛡️ Sentinel: Fix command injection in git_ops.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - Command Injection via `shell=True` and `cmd /c`
+**Vulnerability:** Functions in `backend/git_ops.py` used `subprocess.run` with `shell=True` and string-joined arguments (e.g., `f'cmd /c "git {" ".join(args)}"'`), allowing arbitrary command execution via shell operators in `args`.
+**Learning:** Using `shell=True` even with a list of arguments joined by spaces is insecure. The `cmd /c` prefix also introduced a hard dependency on Windows, which failed on POSIX systems.
+**Prevention:** Always use `shell=False` and pass arguments as a list. Use `sys.executable` to refer to the current Python interpreter for cross-platform reliability. Avoid `cmd /c` or other shell-specific wrappers unless absolutely necessary and sanitized.

--- a/backend/git_ops.py
+++ b/backend/git_ops.py
@@ -8,6 +8,7 @@ import logging
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 logger = logging.getLogger("localmind.autonomy.git")
@@ -18,13 +19,16 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 def git_run(args: list[str]) -> str:
     """Run a git command in the project root. Returns stdout."""
     try:
+        # Security: Use list of arguments and shell=False to prevent injection.
+        # We also drop 'cmd /c' and use 'git' directly for cross-platform compatibility.
+        cmd = ["git"] + args
         result = subprocess.run(
-            f'cmd /c "git {" ".join(args)}"',
+            cmd,
             cwd=str(PROJECT_ROOT),
             capture_output=True,
             text=True,
             timeout=30,
-            shell=True,
+            shell=False,
         )
         if result.returncode != 0:
             error = result.stderr.strip() or f"git exited with code {result.returncode}"
@@ -80,12 +84,13 @@ async def run_tests(target_files: list[str] = None) -> tuple[bool, str]:
             test_targets = ["tests/"]
 
     try:
-        test_args = " ".join(test_targets + ["-q", "--tb=short", "-x"])
+        # Security: Avoid shell=True and manual string concatenation for commands.
+        cmd = [sys.executable, "-m", "pytest"] + test_targets + ["-q", "--tb=short", "-x"]
         result = subprocess.run(
-            f'cmd /c "python -m pytest {test_args}"',
+            cmd,
             capture_output=True, text=True, timeout=180,
             cwd=str(PROJECT_ROOT),
-            shell=True,
+            shell=False,
         )
 
         output = result.stdout.strip() or result.stderr.strip()
@@ -121,11 +126,13 @@ def count_tests() -> int:
     Uses --collect-only for speed. Returns 0 on error.
     """
     try:
+        # Security: Avoid shell=True.
+        cmd = [sys.executable, "-m", "pytest", "tests/", "--collect-only", "-q"]
         result = subprocess.run(
-            'cmd /c "python -m pytest tests/ --collect-only -q"',
+            cmd,
             capture_output=True, text=True, timeout=30,
             cwd=str(PROJECT_ROOT),
-            shell=True,
+            shell=False,
         )
         # Output ends with "X tests collected"
         for line in result.stdout.splitlines():


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection in `backend/git_ops.py` due to use of `shell=True` and string-joined arguments.
🎯 Impact: An attacker (or a malicious agent) could execute arbitrary shell commands on the server by injecting shell operators into git arguments.
🔧 Fix: Refactored `git_run`, `run_tests`, and `count_tests` to use `subprocess.run` with `shell=False` and a list of arguments. Switched to `sys.executable` for reliability and removed Windows-specific `cmd /c` prefix.
✅ Verification: Confirmed with a reproduction script that injection attempts are now blocked, while valid commands continue to function correctly. Existing tests in `tests/test_git_tools.py` also pass.

---
*PR created automatically by Jules for task [12700889928473206234](https://jules.google.com/task/12700889928473206234) started by @SamDeiter*