### PR TITLE
🎨 Palette: Improve Chat Control & Conversation Safety

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -3,3 +3,7 @@
 ## 2025-05-15 - [Enhanced Voice Feedback & Typing Visibility]
 **Learning:** Interactive elements like voice input and typing indicators are crucial for user experience but often lack clear visual feedback or accessibility considerations. A pulsing animation for the active microphone provides immediate, non-intrusive feedback, while dynamic `aria-label` updates ensure accessibility for screen readers. Consistent styling for typing indicators across the application prevents fragmented user experiences.
 **Action:** Always ensure interactive states have distinct visual cues and corresponding accessibility attributes to maintain a delightful and inclusive interface.
+
+## 2025-05-24 - [Destructive Actions & Session Decoupling]
+**Learning:** Users require explicit confirmation before irreversible actions like deleting conversations to prevent data loss. Furthermore, starting a 'New Chat' must explicitly reset internal session identifiers (like `currentConvId`) to ensure the subsequent message is correctly handled as a new thread, preventing accidental message linkage or leakage. Icon-only buttons should always use semantic labels and accessible focus states.
+**Action:** Always wrap delete operations in confirmation dialogs and verify state resets during session transitions. Use ARIA labels and focus-visible triggers for interactive components.

--- a/frontend/__tests__/conversations.test.js
+++ b/frontend/__tests__/conversations.test.js
@@ -97,3 +97,47 @@ describe("loadConversations", () => {
     expect(renderSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("deleteConversation", () => {
+  let originalFetch;
+  let originalConfirm;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+    originalConfirm = global.confirm;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    global.confirm = originalConfirm;
+  });
+
+  beforeEach(() => {
+    global.confirm = jest.fn();
+    global.fetch = jest.fn();
+    state.currentConvId = "123";
+  });
+
+  test("does nothing if user cancels confirmation", async () => {
+    global.confirm.mockReturnValue(false);
+
+    await conv.deleteConversation("123");
+
+    expect(global.confirm).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(state.currentConvId).toBe("123");
+  });
+
+  test("proceeds with deletion if user confirms", async () => {
+    global.confirm.mockReturnValue(true);
+    global.fetch.mockResolvedValue({ ok: true });
+
+    await conv.deleteConversation("123");
+
+    expect(global.confirm).toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("/api/conversations/123"), {
+      method: "DELETE",
+    });
+    expect(state.currentConvId).toBeNull();
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -330,10 +330,17 @@
                                         <span class="material-symbols-outlined text-lg">volume_up</span>
                                     </button>
                                 </div>
-                                <button id="sendBtn" aria-label="Send Message" title="Send this message"
-                                    class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
-                                    <span class="material-symbols-outlined text-lg">arrow_upward</span>
-                                </button>
+                                <div class="flex items-center gap-1">
+                                    <button id="stopBtn" aria-label="Stop Generation" title="Stop generating response"
+                                        class="p-2 rounded-lg text-red-500 hover:text-red-400 hover:bg-red-500/10 transition-all border border-red-500/20"
+                                        style="display: none">
+                                        <span class="material-symbols-outlined text-lg">block</span>
+                                    </button>
+                                    <button id="sendBtn" aria-label="Send Message" title="Send this message"
+                                        class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
+                                        <span class="material-symbols-outlined text-lg">arrow_upward</span>
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/frontend/modules/conversations.js
+++ b/frontend/modules/conversations.js
@@ -30,9 +30,13 @@ export function renderConversations() {
     }`;
     div.innerHTML = `
       <span class="truncate pr-2 pointer-events-none">${escapeHtml(c.title || "New Chat")}</span>
-      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button class="export-btn p-1 text-outline hover:text-secondary rounded" title="Export">📥</button>
-        <button class="delete-btn p-1 text-outline hover:text-error rounded" title="Delete">✕</button>
+      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        <button class="export-btn p-1 text-outline hover:text-secondary rounded flex items-center justify-center" title="Export" aria-label="Export conversation">
+          <span class="material-symbols-outlined text-[18px]">download</span>
+        </button>
+        <button class="delete-btn p-1 text-outline hover:text-error rounded flex items-center justify-center" title="Delete" aria-label="Delete conversation">
+          <span class="material-symbols-outlined text-[18px]">delete</span>
+        </button>
       </div>`;
     div.addEventListener("click", () => loadConversation(c.id));
     div.querySelector(".delete-btn").addEventListener("click", (e) => {
@@ -63,6 +67,7 @@ export async function loadConversation(id) {
 }
 
 export async function deleteConversation(id) {
+  if (!confirm("Are you sure you want to delete this conversation? This action cannot be undone.")) return;
   try {
     await fetch(`${API}/api/conversations/${id}`, { method: "DELETE" });
     if (state.currentConvId === id) {

--- a/frontend/modules/events.js
+++ b/frontend/modules/events.js
@@ -188,6 +188,7 @@ export function bindEvents() {
 
   // Chat tab: new conversation inline button
   document.getElementById("newChatInlineBtn")?.addEventListener("click", () => {
+    state.currentConvId = null;
     clearMessages?.();
     loadConversations?.();
   });

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.9.1",
-  "build": 262,
+  "build": 267,
   "codename": "Phase 9 \u2014 Intelligence",
-  "last_built": "2026-04-09T13:27:40.041393+00:00"
+  "last_built": "2026-05-25T02:24:10.285355+00:00"
 }


### PR DESCRIPTION
This PR implements several micro-UX improvements focused on safety, accessibility, and control:

1. **Stop Generation Control**: Added the missing `#stopBtn` to `index.html`. This button appears during AI response streaming, allowing users to immediately abort long-running generations.
2. **Conversation Safety**: Added a standard `confirm()` prompt before deleting a conversation.
3. **Session Integrity**: Fixed a bug where the `currentConvId` was not reset when starting a new chat, ensuring that new messages are correctly started in a fresh thread.
4. **Accessibility Enhancements**:
    - Replaced non-standard emojis with semantic Material Symbols.
    - Added `aria-label` attributes to icon-only buttons for screen readers.
    - Added `group-focus-within` styles to ensure sidebar actions are visible during keyboard navigation.

Verified via:
- ESLint and Jest (added new tests for deletion confirmation).
- Visual verification via Playwright screenshot/video recording.

---
*PR created automatically by Jules for task [9728088176405422930](https://jules.google.com/task/9728088176405422930) started by @SamDeiter*