### PR TITLE
🛡️ Sentinel: Harden TerminalTool against command obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-15 - Command Obfuscation bypass in TerminalTool
+**Vulnerability:** Shell commands can be obfuscated using backslashes (e.g., `r\m`), quotes (e.g., `"rm"`), or ANSI escape sequences (e.g., `\x1b[0mrm`) to bypass simple regex-based blocklists.
+**Learning:** Simple string matching or regexes without normalization are insufficient for shell security because shells have complex parsing rules that ignore certain characters.
+**Prevention:** Implement a normalization step that strips obfuscation characters (backslashes, quotes, ANSI codes) before performing security scans. Ensure that the original command is still preserved for execution if it passes the security check or is approved by the user.

--- a/backend/tools/terminal.py
+++ b/backend/tools/terminal.py
@@ -4,10 +4,12 @@ Provides safe shell execution with stderr/stdout capturing.
 """
 
 import asyncio
+import logging
 import re
 from typing import Any
-import logging
+
 from backend.config import PROJECT_ROOT
+
 from .base import BaseTool
 from .propose_action import ProposeActionTool
 
@@ -16,13 +18,26 @@ logger = logging.getLogger("localmind.tools.terminal")
 # Security: Block dangerous commands and shell operators.
 # Use word boundaries (\b) to prevent bypasses (e.g. 'army' instead of 'rm').
 DANGEROUS_PATTERN = re.compile(
-    r"\b(rm|del|pip install|npm install|apt|cargo install|format|curl|wget|git push)\b",
+    r"\b(rm|del|pip install|npm install|apt|cargo install|format|curl|wget|git push|sudo|su|chmod|chown|"
+    r"dd|reboot|shutdown|mv|mkfs|nc|netcat)\b",
     re.IGNORECASE
 )
 # Shell operator detection to prevent command chaining bypasses.
 SHELL_OPERATORS = re.compile(r"[;&|\n]")
 
+# ANSI escape sequence regex for normalization.
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
 class TerminalTool(BaseTool):
+    @staticmethod
+    def _normalize(cmd: str) -> str:
+        """Strip obfuscation characters (backslashes, quotes, ANSI) for security scanning."""
+        # 1. Remove ANSI escape sequences
+        cmd = ANSI_ESCAPE.sub("", cmd)
+        # 2. Remove backslashes and quotes used for shell obfuscation
+        cmd = cmd.replace("\\", "").replace("'", "").replace('"', "")
+        return cmd
+
     @property
     def name(self) -> str:
         return "terminal"
@@ -48,11 +63,15 @@ class TerminalTool(BaseTool):
     async def execute(self, **kwargs) -> dict[str, Any]:
         command = kwargs.get("command", "")
         timeout = kwargs.get("timeout", 10)
-        
+
         # Security: Multi-stage check for dangerous patterns and shell chaining.
         # We split by operators to check EACH command in a chain.
         commands_to_check = SHELL_OPERATORS.split(command)
-        is_dangerous = any(DANGEROUS_PATTERN.search(cmd) for cmd in commands_to_check)
+
+        # Normalize EACH command part before checking against the blocklist.
+        # This prevents bypasses like 'r\m' or '"rm"'.
+        normalized_commands = [self._normalize(cmd) for cmd in commands_to_check]
+        is_dangerous = any(DANGEROUS_PATTERN.search(cmd) for cmd in normalized_commands)
 
         if is_dangerous:
             proposer = ProposeActionTool()
@@ -64,7 +83,7 @@ class TerminalTool(BaseTool):
             )
             if not app_req.get("approved"):
                 return {"success": False, "error": "User denied execution of dangerous command."}
-        
+
         try:
             # Use asyncio subprocess for non-blocking execution safely.
             # Security: Ensure cwd is always within the project root.
@@ -77,7 +96,7 @@ class TerminalTool(BaseTool):
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             out = stdout.decode().strip()
             err = stderr.decode().strip()
-            
+
             return {
                 "success": proc.returncode == 0,
                 "stdout": out[:2000] if out else "",

--- a/tests/test_terminal_security.py
+++ b/tests/test_terminal_security.py
@@ -68,3 +68,48 @@ async def test_terminal_tool_bypass_attempt():
             assert result["success"] is True
             # Proposer should NOT have been called
             assert MockProposer.call_count == 0
+
+@pytest.mark.asyncio
+async def test_terminal_tool_obfuscation_bypasses():
+    tool = TerminalTool()
+
+    # Mock ProposeActionTool
+    with patch("backend.tools.terminal.ProposeActionTool") as MockProposer:
+        mock_proposer_instance = MockProposer.return_value
+        mock_proposer_instance.execute = AsyncMock(return_value={"approved": False})
+
+        # Test backslash escape
+        result = await tool.execute(command="r\\m -rf /")
+        assert result["success"] is False
+        assert MockProposer.call_count == 1
+        MockProposer.reset_mock()
+
+        # Test single quotes
+        result = await tool.execute(command="'rm' -rf /")
+        assert result["success"] is False
+        assert MockProposer.call_count == 1
+        MockProposer.reset_mock()
+
+        # Test double quotes
+        result = await tool.execute(command='"rm" -rf /')
+        assert result["success"] is False
+        assert MockProposer.call_count == 1
+        MockProposer.reset_mock()
+
+        # Test ANSI escape sequence
+        # \x1b[31m is red text
+        result = await tool.execute(command="\x1b[31mrm\x1b[0m -rf /")
+        assert result["success"] is False
+        assert MockProposer.call_count == 1
+        MockProposer.reset_mock()
+
+        # Test expanded blocklist: sudo
+        result = await tool.execute(command="sudo apt-get update")
+        assert result["success"] is False
+        assert MockProposer.call_count == 1
+        MockProposer.reset_mock()
+
+        # Test expanded blocklist: nc
+        result = await tool.execute(command="nc -l -p 1234")
+        assert result["success"] is False
+        assert MockProposer.call_count == 1


### PR DESCRIPTION
Hardened the `TerminalTool` to prevent security bypasses via command obfuscation (e.g., `r\m`, `"rm"`). Introduced a normalization layer that cleans commands before blocklist validation and expanded the list of restricted commands for better defense-in-depth.

---
*PR created automatically by Jules for task [9606216643544789854](https://jules.google.com/task/9606216643544789854) started by @SamDeiter*