### PR TITLE
🛡️ Sentinel: Fix Command Injection Vulnerabilities in Backend Tools

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-06-01 - Command Injection via `shell=True` and Import Ambiguity
+**Vulnerability:** Using `subprocess.run(..., shell=True)` with string-formatted commands allows arbitrary command execution. Additionally, the coexistence of `backend/tools.py` and `backend/tools/` package caused import ambiguity, complicating security verification.
+**Learning:** `shell=True` should be avoided in favor of list-based arguments with `shell=False`. When verifying fixes, be aware of package/module name collisions that might mask the code being tested.
+**Prevention:** Always use list-based `subprocess.run` and `shlex.split` for dynamic commands. Maintain clear separation between package names and module names to avoid shadowing imports.

--- a/backend/git_ops.py
+++ b/backend/git_ops.py
@@ -8,6 +8,7 @@ import logging
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 logger = logging.getLogger("localmind.autonomy.git")
@@ -19,12 +20,12 @@ def git_run(args: list[str]) -> str:
     """Run a git command in the project root. Returns stdout."""
     try:
         result = subprocess.run(
-            f'cmd /c "git {" ".join(args)}"',
+            ["git"] + args,
             cwd=str(PROJECT_ROOT),
             capture_output=True,
             text=True,
             timeout=30,
-            shell=True,
+            shell=False,
         )
         if result.returncode != 0:
             error = result.stderr.strip() or f"git exited with code {result.returncode}"
@@ -80,12 +81,12 @@ async def run_tests(target_files: list[str] = None) -> tuple[bool, str]:
             test_targets = ["tests/"]
 
     try:
-        test_args = " ".join(test_targets + ["-q", "--tb=short", "-x"])
+        cmd = [sys.executable, "-m", "pytest"] + test_targets + ["-q", "--tb=short", "-x"]
         result = subprocess.run(
-            f'cmd /c "python -m pytest {test_args}"',
+            cmd,
             capture_output=True, text=True, timeout=180,
             cwd=str(PROJECT_ROOT),
-            shell=True,
+            shell=False,
         )
 
         output = result.stdout.strip() or result.stderr.strip()
@@ -122,10 +123,10 @@ def count_tests() -> int:
     """
     try:
         result = subprocess.run(
-            'cmd /c "python -m pytest tests/ --collect-only -q"',
+            [sys.executable, "-m", "pytest", "tests/", "--collect-only", "-q"],
             capture_output=True, text=True, timeout=30,
             cwd=str(PROJECT_ROOT),
-            shell=True,
+            shell=False,
         )
         # Output ends with "X tests collected"
         for line in result.stdout.splitlines():

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import glob
 import json
+import shlex
 from pathlib import Path
 
 # Maximum characters to return from file reads / command output
@@ -125,9 +126,12 @@ def list_directory(path: str = ".", working_dir: str = ".") -> dict:
 def run_command(command: str, working_dir: str) -> dict:
     """Execute a shell command in the working directory."""
     try:
+        # Security: Use shlex.split for argument parsing and shell=False to prevent
+        # command injection via shell metacharacters.
+        args = shlex.split(command, posix=(os.name != "nt"))
         result = subprocess.run(
-            command,
-            shell=True,
+            args,
+            shell=False,
             capture_output=True,
             text=True,
             timeout=60,


### PR DESCRIPTION
I have identified and fixed critical command injection vulnerabilities in `backend/git_ops.py` and `backend/tools.py`. These files were using `subprocess.run` with `shell=True` and string-formatted commands, which allowed for arbitrary command execution by injecting shell metacharacters.

The fixes involved:
1.  **`backend/git_ops.py`**: Switched `git_run`, `run_tests`, and `count_tests` to use list-based arguments for `subprocess.run` and set `shell=False`. I also used `sys.executable` to ensure the correct Python interpreter is used for running tests.
2.  **`backend/tools.py`**: Switched `run_command` to use `shlex.split(command, posix=(os.name != "nt"))` to safely parse the command string and set `shell=False` to prevent shell-level injection.

These changes were verified using custom reproduction scripts that confirmed the vulnerabilities are no longer exploitable. I also ran the existing test suite (`tests/test_tools.py`, `tests/test_git_tools.py`, `tests/test_terminal_security.py`) to ensure no regressions were introduced.

Additionally, I updated the Sentinel journal in `.jules/sentinel.md` to document the findings and the preventative measures taken.

---
*PR created automatically by Jules for task [803721788022924828](https://jules.google.com/task/803721788022924828) started by @SamDeiter*