### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal bypass in PromptGuard

### DIFF
--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,9 +29,15 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
-        """Fallback: resolve without jail check."""
-        return Path(path).resolve()
+    def safe_resolve(base: Path | str, path: str | Path) -> Path:  # type: ignore[misc]
+        """Fallback: basic jail check (Fail Closed)."""
+        base_path = Path(base).resolve()
+        target_path = (base_path / path).resolve()
+        try:
+            target_path.relative_to(base_path)
+        except ValueError:
+            raise RuntimeError(f"Security fallback: {path} escapes {base}")
+        return target_path
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -487,18 +493,16 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
-                            issues.append(
-                                f"Arg '{arg_name}' escapes job directory: {resolved}"
-                            )
-                            logger.warning(
-                                "Path escape attempt in tool arg %s.%s: %r -> %s",
-                                tool_name, arg_name, arg_value, resolved,
-                            )
+                        # Security: safe_resolve(base_dir, untrusted_path)
+                        # It handles symlinks and ensures the path stays inside base_dir.
+                        safe_resolve(job_dir, arg_value)
                     except Exception as exc:
                         issues.append(
-                            f"Arg '{arg_name}' path resolution failed: {exc}"
+                            f"Arg '{arg_name}' path resolution failed or escapes jail: {exc}"
+                        )
+                        logger.warning(
+                            "Path escape attempt in tool arg %s.%s: %r. Error: %s",
+                            tool_name, arg_name, arg_value, exc,
                         )
 
         valid = len(issues) == 0


### PR DESCRIPTION
This PR fixes a high-severity path traversal vulnerability in the `PromptGuard` component.

### 🚨 Severity: HIGH
### 💡 Vulnerability:
The `PromptGuard.validate_tool_call` function, which is responsible for sandboxing file paths generated by the LLM, had two critical flaws:
1. **Argument Swap**: It called `safe_resolve(arg_value, job_dir)` instead of `safe_resolve(job_dir, arg_value)`. This meant the untrusted user path was being used as the "jail," effectively bypassing the security check.
2. **Insecure Prefix Check**: It used a redundant `str(resolved).startswith(str(job_dir))` check. As documented in `.jules/sentinel.md`, string-based prefix checks are vulnerable to traversal into sibling directories that share a prefix (e.g., `/app/workspace_evil` passing against `/app/workspace`).

### 🎯 Impact:
An attacker could use prompt injection to trick the LLM into calling tools (like `read_file` or `write_file`) with paths that escape the intended job sandbox, potentially accessing or modifying sensitive system files.

### 🔧 Fix:
- Corrected the `safe_resolve` call order.
- Removed the insecure `startswith` check, relying on the robust validation already performed by the `safe_resolve` utility.
- Hardened the `safe_resolve` fallback implementation to "Fail Closed" using `Path.relative_to`.

### ✅ Verification:
- Created and ran a reproduction script that demonstrated a path traversal bypass via prefix matching.
- Verified the script now correctly blocks the escape after the fix.
- Ran all existing security and auth tests (`pytest tests/test_security.py tests/test_terminal_security.py tests/test_auth_rbac.py`), all 111 passed.

---
*PR created automatically by Jules for task [11795492598406757922](https://jules.google.com/task/11795492598406757922) started by @SamDeiter*