### PR TITLE
🛡️ Sentinel: [security improvement] Harden PromptGuard validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-06-14 - Argument Order Mismatch in Security Fallbacks
+**Vulnerability:** The `safe_resolve` fallback in `prompt_guard.py` had its arguments reversed compared to the primary implementation in `paths.py` (`(path, base)` vs `(base, path)`), leading to incorrect path resolution when the `paths` module was unavailable.
+**Learning:** Fallback implementations of security-critical functions must be rigorously tested to match the primary API's signature and behavior.
+**Prevention:** Use type-checked shared interfaces or centralized definitions to ensure consistency between primary and fallback security utilities.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,7 +29,7 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
+    def safe_resolve(base: Path, path: str | Path) -> Path:  # type: ignore[misc]
         """Fallback: resolve without jail check."""
         return Path(path).resolve()
 
@@ -39,7 +39,10 @@ except ImportError:  # paths module not yet available (circular / missing)
 
 MAX_INPUT_LENGTH: int = 50_000
 
-SHELL_METACHARACTERS: set[str] = {";", "|", "&", "$", "`", "\\"}
+SHELL_METACHARACTERS: set[str] = {
+    ";", "|", "&", "$", "`", "\\", "\n", "\r", ">", "<", "(", ")",
+    "{", "}", "*", "?", "[", "]", "!", "~",
+}
 
 SSRF_PATTERNS: list[str] = [
     r"^file://",
@@ -487,8 +490,12 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        resolved = safe_resolve(job_dir, arg_value)
+                        # safe_resolve already performs a jail check, but we re-verify here
+                        # using a more robust method than startswith().
+                        try:
+                            resolved.relative_to(job_dir.resolve())
+                        except ValueError:
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )


### PR DESCRIPTION
This PR hardens the `PromptGuard` security component against path traversal and command injection bypasses.

Key changes:
1.  **Robust Path Jailing**: Replaced `str.startswith()` with `Path.relative_to()` in `validate_tool_call`. The previous string-based check was vulnerable to prefix-collision attacks (e.g., `/app/job` matching `/app/job_secrets`).
2.  **Signature Alignment**: Fixed the `safe_resolve` fallback signature in `prompt_guard.py` to match the primary implementation in `paths.py` (`base` first, `path` second). This corrected a bug where path resolution was failing when the `paths` module was not available.
3.  **Command Injection Defense**: Expanded the list of blocked shell metacharacters to include newlines (`\n`, `\r`), redirection operators (`>`, `<`), and common shell expansion characters (`*`, `?`, `()`, etc.). This provides defense-in-depth against multi-stage command injection and output redirection.
4.  **Verification**: Verified the fixes using a reproduction script that confirmed the vulnerabilities and their resolution. Existing security tests also pass.

---
*PR created automatically by Jules for task [6851653494047790387](https://jules.google.com/task/6851653494047790387) started by @SamDeiter*