### PR TITLE
🛡️ Sentinel: [HIGH] Harden path jailing and fix validation bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,13 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-05-22 - Path Traversal bypass via Backslashes on POSIX
+**Vulnerability:** On POSIX systems, `pathlib` does not treat backslashes (`\`) as path separators. A security filter that only checks for forward slashes or uses `Path.relative_to` without normalization may fail to detect traversal attempts using backslashes if the path is later used in a context that does interpret them (like a Windows-compatible shell or certain libraries).
+**Learning:** Path normalization must account for both forward and backward slashes regardless of the host OS to ensure consistent security policy enforcement.
+**Prevention:** Normalize all backslashes to forward slashes before performing jail checks on POSIX systems.
+
+## 2024-05-22 - Security Fallback "Fail-Open" Risk
+**Vulnerability:** Moving security logic into a centralized utility and removing it from callers can create a "fail-open" vulnerability if the utility's fallback implementation (e.g., in case of import errors) does not maintain the same level of security.
+**Learning:** Centralized security utilities must have robust, secure fallback implementations or explicitly fail closed (e.g., by raising an exception) if their primary logic cannot be loaded.
+**Prevention:** Always implement basic security checks in fallback functions or ensure they raise errors for unsafe operations.

--- a/backend/security/paths.py
+++ b/backend/security/paths.py
@@ -168,6 +168,12 @@ def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:
     # Strip leading POSIX or Windows root separators.
     user_path_stripped = user_path_stripped.lstrip("/\\")
 
+    # On POSIX systems, backslashes are NOT separators and could be part of a filename.
+    # However, LocalMind treats both / and \ as separators for security consistency.
+    if os.name != "nt" and "\\" in user_path_stripped:
+        user_path_stripped = user_path_stripped.replace("\\", "/")
+        logger.debug("Normalized backslashes to forward slashes in user path")
+
     candidate = resolved_base / user_path_stripped
 
     # --- Resolve ALL symlinks in candidate ---------------------------------
@@ -179,24 +185,12 @@ def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:
             f"Cannot resolve candidate path {candidate!r}: {exc}"
         ) from exc
 
-    # --- Enforce jail via string prefix comparison -------------------------
-    # We must compare strings (not Path parents) so that a jail at
-    # /data/uploads does NOT match /data/uploads_evil.
-    # Add the OS separator to avoid that exact prefix-collision scenario.
-    resolved_base_str = str(resolved_base)
-    resolved_candidate_str = str(resolved_candidate)
-
-    # Normalise case on Windows (NTFS is case-insensitive).
-    if os.name == "nt":
-        resolved_base_str = resolved_base_str.lower()
-        resolved_candidate_str = resolved_candidate_str.lower()
-
-    jail_prefix = resolved_base_str.rstrip(os.sep) + os.sep
-
-    if not (
-        resolved_candidate_str == resolved_base_str.rstrip(os.sep)
-        or resolved_candidate_str.startswith(jail_prefix)
-    ):
+    # --- Enforce jail via segment-aware comparison -------------------------
+    # We use Path.relative_to to ensure the candidate is strictly under base.
+    # This avoids prefix bypasses like /app/workspace matching /app/workspace_evil.
+    try:
+        resolved_candidate.relative_to(resolved_base)
+    except ValueError:
         logger.warning(
             "Path escape attempt: %r resolved to %r, outside jail %r",
             user_path_str,

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,9 +29,16 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
-        """Fallback: resolve without jail check."""
-        return Path(path).resolve()
+    def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:  # type: ignore[misc]
+        """Fallback: basic string-based jail check if primary implementation is missing."""
+        base = Path(base_dir).resolve()
+        # Strip separators and resolve
+        path_str = str(user_path).lstrip("/\\")
+        candidate = (base / path_str).resolve()
+        # Basic check
+        if not str(candidate).startswith(str(base)):
+            raise ValueError(f"Path {user_path} escapes jail {base_dir}")
+        return candidate
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -487,18 +494,14 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
-                            issues.append(
-                                f"Arg '{arg_name}' escapes job directory: {resolved}"
-                            )
-                            logger.warning(
-                                "Path escape attempt in tool arg %s.%s: %r -> %s",
-                                tool_name, arg_name, arg_value, resolved,
-                            )
+                        safe_resolve(job_dir, arg_value)
                     except Exception as exc:
                         issues.append(
-                            f"Arg '{arg_name}' path resolution failed: {exc}"
+                            f"Arg '{arg_name}' path resolution failed or escapes jail: {exc}"
+                        )
+                        logger.warning(
+                            "Path validation failed in tool arg %s.%s: %r (%s)",
+                            tool_name, arg_name, arg_value, exc,
                         )
 
         valid = len(issues) == 0

--- a/tests/test_path_jailing_fix.py
+++ b/tests/test_path_jailing_fix.py
@@ -1,0 +1,92 @@
+
+import pytest
+from pathlib import Path
+from backend.security.prompt_guard import PromptGuard
+
+def test_path_jailing_traversal_blocked():
+    """Verify that path traversal attempts are blocked in validate_tool_call."""
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/app/jobs/job_123").resolve()
+
+    # Payload trying to escape job_dir
+    payload = {
+        "name": "read_file",
+        "args": {"path": "../../etc/passwd"}
+    }
+
+    result = guard.validate_tool_call(payload, allowed_tools=["read_file"], job_dir=job_dir)
+
+    assert not result.valid
+    assert any("escapes jail" in issue for issue in result.issues)
+
+def test_path_jailing_prefix_bypass_blocked():
+    """Verify that prefix-based jailing bypasses are blocked (segment-aware)."""
+    guard = PromptGuard(level="strict")
+    # Base directory
+    job_dir = Path("/app/jobs/job_1").resolve()
+
+    # "job_1_evil" starts with "job_1" but is a different directory
+    payload = {
+        "name": "read_file",
+        "args": {"path": "../job_1_evil/secret.txt"}
+    }
+
+    result = guard.validate_tool_call(payload, allowed_tools=["read_file"], job_dir=job_dir)
+
+    assert not result.valid
+    assert any("escapes jail" in issue for issue in result.issues)
+
+def test_path_jailing_absolute_path_stripped_stays_in_jail():
+    """Verify that absolute paths are stripped and kept inside the jail."""
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/tmp/localmind_test_job_abs").resolve()
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Create a file that WOULD be hit if /etc/passwd was stripped to etc/passwd
+        # inside the jail.
+        jail_etc = job_dir / "etc"
+        jail_etc.mkdir()
+        jail_passwd = jail_etc / "passwd"
+        jail_passwd.write_text("jailed")
+
+        payload = {
+            "name": "read_file",
+            "args": {"path": "/etc/passwd"}
+        }
+
+        result = guard.validate_tool_call(payload, allowed_tools=["read_file"], job_dir=job_dir)
+
+        # Current implementation strips leading slash and resolves it relative to job_dir.
+        # This is considered valid and safe since it stays in jail.
+        assert result.valid
+        assert not result.issues
+
+    finally:
+        import shutil
+        if job_dir.exists():
+            shutil.rmtree(job_dir)
+
+def test_path_jailing_valid_path_allowed():
+    """Verify that valid paths inside the jail are allowed."""
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/tmp/localmind_test_job").resolve()
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        valid_file = job_dir / "data.txt"
+        valid_file.write_text("hello")
+
+        payload = {
+            "name": "read_file",
+            "args": {"path": "data.txt"}
+        }
+
+        result = guard.validate_tool_call(payload, allowed_tools=["read_file"], job_dir=job_dir)
+
+        assert result.valid
+        assert not result.issues
+    finally:
+        import shutil
+        if job_dir.exists():
+            shutil.rmtree(job_dir)


### PR DESCRIPTION
Harden path jailing with segment-aware validation, fix argument order bug in PromptGuard, and prevent fail-open regression in fallback logic.

---
*PR created automatically by Jules for task [3465876403282908725](https://jules.google.com/task/3465876403282908725) started by @SamDeiter*