### PR TITLE
🛡️ Sentinel: Harden RunCodeTool blocklist against shell bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-10-24 - RunCode Sandbox Bypass via Shell/Process Functions
+**Vulnerability:** The `RunCodeTool` used a regex blocklist that missed common Python functions for process creation and shell execution like `os.system`, `subprocess`, and `os.popen`. This allowed an attacker to execute arbitrary shell commands, bypassing the restrictions intended for the tool.
+**Learning:** Regex-based blocklists for code execution must be comprehensive and include dynamic access methods like `getattr` and `__builtins__` to prevent obfuscated bypasses.
+**Prevention:** Explicitly block all known process-spawning modules and functions, and restrict access to low-level Python internals in the pre-execution scan.

--- a/backend/tools/run_code.py
+++ b/backend/tools/run_code.py
@@ -32,6 +32,16 @@ BLOCKLIST_PATTERNS = [
     r"\b__import__\s*\(\s*['\"]os['\"]\s*\)\s*\.remove\b",
     r"\bexec\s*\(",
     r"\beval\s*\(",
+    # Shell execution and process management bypasses
+    r"\bos\.(system|popen|spawn)",
+    r"\bsubprocess\b",
+    r"\bpty\.spawn\b",
+    # Dynamic attribute access / Builtin manipulation
+    r"\bgetattr\b",
+    r"\bsetattr\b",
+    r"\b__builtins__\b",
+    r"\bimportlib\b",
+    r"\bsys\.modules\b",
 ]
 
 

--- a/tests/test_run_code_hardened.py
+++ b/tests/test_run_code_hardened.py
@@ -1,0 +1,46 @@
+import pytest
+from backend.tools.run_code import RunCodeTool
+
+@pytest.mark.asyncio
+async def test_run_code_blocks_os_system():
+    tool = RunCodeTool()
+    code = "import os; os.system('ls')"
+    result = await tool.execute(code=code)
+    assert result["success"] is False
+    assert "BLOCKED" in result["error"]
+    assert "os.system" in result["error"]
+
+@pytest.mark.asyncio
+async def test_run_code_blocks_subprocess():
+    tool = RunCodeTool()
+    code = "import subprocess; subprocess.run(['ls'])"
+    result = await tool.execute(code=code)
+    assert result["success"] is False
+    assert "BLOCKED" in result["error"]
+    assert "subprocess" in result["error"]
+
+@pytest.mark.asyncio
+async def test_run_code_blocks_getattr():
+    tool = RunCodeTool()
+    code = "getattr(os, 'system')('ls')"
+    result = await tool.execute(code=code)
+    assert result["success"] is False
+    assert "BLOCKED" in result["error"]
+    assert "getattr" in result["error"]
+
+@pytest.mark.asyncio
+async def test_run_code_blocks_builtins():
+    tool = RunCodeTool()
+    code = "print(__builtins__)"
+    result = await tool.execute(code=code)
+    assert result["success"] is False
+    assert "BLOCKED" in result["error"]
+    assert "__builtins__" in result["error"]
+
+@pytest.mark.asyncio
+async def test_run_code_allows_safe_code():
+    tool = RunCodeTool()
+    code = "print('Hello, World!')"
+    result = await tool.execute(code=code)
+    assert result["success"] is True
+    assert result["result"] == "Hello, World!"


### PR DESCRIPTION
Hardened the `RunCodeTool` by expanding its regex-based blocklist to include common Python functions for shell execution and process management, as well as dynamic attribute access methods. This prevents agents from bypassing tool-specific restrictions by executing arbitrary shell commands via Python. Verified the fix with a new test suite and updated the security journal.

---
*PR created automatically by Jules for task [10299635588892389500](https://jules.google.com/task/10299635588892389500) started by @SamDeiter*