### PR TITLE
🎨 Palette: Chat Accessibility & UX Polishing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -330,10 +330,16 @@
                                         <span class="material-symbols-outlined text-lg">volume_up</span>
                                     </button>
                                 </div>
-                                <button id="sendBtn" aria-label="Send Message" title="Send this message"
-                                    class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
-                                    <span class="material-symbols-outlined text-lg">arrow_upward</span>
-                                </button>
+                                <div class="flex items-center gap-2">
+                                    <button id="stopBtn" aria-label="Stop Generating" title="Stop generating"
+                                        class="p-2 rounded-lg text-red-500 hover:bg-red-500/10 transition-all" style="display: none;">
+                                        <span class="material-symbols-outlined text-lg">stop_circle</span>
+                                    </button>
+                                    <button id="sendBtn" aria-label="Send Message" title="Send this message"
+                                        class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
+                                        <span class="material-symbols-outlined text-lg">arrow_upward</span>
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/frontend/modules/conversations.js
+++ b/frontend/modules/conversations.js
@@ -21,6 +21,12 @@ export function renderConversations() {
   const list = document.getElementById("conversationList");
   if (!list) return;
   list.innerHTML = "";
+
+  if (state.conversations.length === 0) {
+    list.innerHTML = `<div class="text-xs text-slate-600 italic px-3 py-4 text-center">No conversations yet</div>`;
+    return;
+  }
+
   state.conversations.forEach((c) => {
     const div = document.createElement("div");
     div.className = `conversation-item flex items-center justify-between px-3 py-2 text-sm rounded-r-lg cursor-pointer transition-all group ${
@@ -30,9 +36,13 @@ export function renderConversations() {
     }`;
     div.innerHTML = `
       <span class="truncate pr-2 pointer-events-none">${escapeHtml(c.title || "New Chat")}</span>
-      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button class="export-btn p-1 text-outline hover:text-secondary rounded" title="Export">📥</button>
-        <button class="delete-btn p-1 text-outline hover:text-error rounded" title="Delete">✕</button>
+      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        <button class="export-btn p-1 text-outline hover:text-secondary rounded flex items-center" title="Export" aria-label="Export conversation">
+          <span class="material-symbols-outlined text-base">download</span>
+        </button>
+        <button class="delete-btn p-1 text-outline hover:text-error rounded flex items-center" title="Delete" aria-label="Delete conversation">
+          <span class="material-symbols-outlined text-base">delete</span>
+        </button>
       </div>`;
     div.addEventListener("click", () => loadConversation(c.id));
     div.querySelector(".delete-btn").addEventListener("click", (e) => {


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the chat interface:

1. **Conversation List Empty State:** Users now see a clear "No conversations yet" message instead of a blank panel when starting fresh.
2. **Iconography & Accessibility:**
   - Swapped out emojis for Material Symbols (`download`, `delete`) to align with the application's design language.
   - Added `aria-label` to icon-only buttons for screen reader compatibility.
   - Added `group-focus-within:opacity-100` to conversation items, allowing keyboard users to see and interact with Export/Delete actions.
3. **Stop Generating Button:** Added the functional `#stopBtn` (Material Symbol: `stop_circle`) next to the send button. This button is automatically managed by the existing `ChatService` streaming logic to allow users to abort long-running AI responses.

All changes were verified visually via Playwright and conform to the < 50 lines per module constraint.

---
*PR created automatically by Jules for task [11149399005726133693](https://jules.google.com/task/11149399005726133693) started by @SamDeiter*