### PR TITLE
🛡️ Sentinel: Fix RBAC prefix bypass and Prompt Guard path jailing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2024-05-25 - RBAC Path Prefix Bypass
+**Vulnerability:** Using `path.startswith(allowed_prefix)` for RBAC authorization allows bypassing restrictions. For example, if `/api/chat` is allowed, an attacker could access `/api/chat_evil` because it shares the same string prefix.
+**Learning:** Prefix matching without boundary awareness (checking for exact match or trailing slash) is insufficient for path-based authorization.
+**Prevention:** Always ensure the path either exactly matches the allowed prefix or starts with `allowed_prefix + "/"`.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -487,8 +487,12 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        # Security fix: Swap arguments to match safe_resolve(base, user_path) signature
+                        resolved = safe_resolve(job_dir, arg_value)
+                        # Defense-in-depth: Verify boundary even if safe_resolve claims to jail.
+                        # Use segment-aware check to avoid prefix bypasses.
+                        job_dir_res = job_dir.resolve()
+                        if not (resolved == job_dir_res or job_dir_res in resolved.parents):
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,13 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Boundary-aware prefix check to prevent bypasses like /api/chat_evil
+        # matching a rule for /api/chat.
+        is_match = (
+            path == allowed_prefix or
+            path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/tests/test_prompt_guard_security.py
+++ b/tests/test_prompt_guard_security.py
@@ -1,0 +1,45 @@
+
+import pytest
+from pathlib import Path
+from backend.security.prompt_guard import PromptGuard
+
+def test_prompt_guard_path_jailing():
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/tmp/job_123")
+
+    # Mock tool call with path escape
+    call = {
+        "name": "read_file",
+        "args": {"path": "../../etc/passwd"}
+    }
+
+    # We need to make sure job_dir exists for resolve() if paths.py is used
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    result = guard.validate_tool_call(
+        call=call,
+        allowed_tools=["read_file"],
+        job_dir=job_dir
+    )
+
+    assert result.valid is False
+    assert any("escapes" in issue or "resolution failed" in issue for issue in result.issues)
+
+def test_prompt_guard_path_valid():
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/tmp/job_123")
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    call = {
+        "name": "read_file",
+        "args": {"path": "data.txt"}
+    }
+
+    result = guard.validate_tool_call(
+        call=call,
+        allowed_tools=["read_file"],
+        job_dir=job_dir
+    )
+
+    assert result.valid is True
+    assert len(result.issues) == 0

--- a/tests/test_rbac_security.py
+++ b/tests/test_rbac_security.py
@@ -1,0 +1,22 @@
+
+import pytest
+from fastapi import HTTPException
+from backend.security.rbac import _is_allowed, check_permission
+
+def test_rbac_prefix_bypass():
+    # 'operator' has access to '/api/chat'
+    # It should NOT have access to '/api/chat_evil'
+
+    assert _is_allowed("operator", "POST", "/api/chat") is True
+    assert _is_allowed("operator", "POST", "/api/chat/messages") is True
+
+    # This is the vulnerability:
+    # If this returns True, it's a bypass.
+    # We WANT it to be False.
+    assert _is_allowed("operator", "POST", "/api/chat_evil") is False
+
+def test_rbac_check_permission_bypass():
+    # Should raise HTTPException for bypass attempt
+    with pytest.raises(HTTPException) as excinfo:
+        check_permission("operator", "POST", "/api/chat_evil")
+    assert excinfo.value.status_code == 403


### PR DESCRIPTION
🛡️ Sentinel: Fix RBAC prefix bypass and Prompt Guard path jailing

Fixed a vulnerability in RBAC where path prefix matching didn't account for directory boundaries, allowing bypasses like `/api/chat_evil` matching `/api/chat`.

Also corrected the argument order in `PromptGuard.validate_tool_call` when calling `safe_resolve`, which was previously causing path jailing checks to fail or behave incorrectly. Added a defense-in-depth segment-aware boundary check in Prompt Guard.

Verification:
- Added `tests/test_rbac_security.py` to verify boundary-aware matching.
- Added `tests/test_prompt_guard_security.py` to verify path jailing.
- Ran `tests/test_terminal_security.py` to ensure no regressions in command validation.
- All 3 suites passed.

---
*PR created automatically by Jules for task [143130543510922293](https://jules.google.com/task/143130543510922293) started by @SamDeiter*