### PR TITLE
🎨 Palette: Enhance conversation list accessibility and feedback

### DIFF
--- a/frontend/modules/conversations.js
+++ b/frontend/modules/conversations.js
@@ -3,7 +3,7 @@
  */
 
 import { API, state, messagesContainer, welcomeScreen } from "./state.js";
-import { escapeHtml } from "./utils.js";
+import { escapeHtml, showToast } from "./utils.js";
 import { renderMessages } from "./chat.js";
 
 export async function loadConversations() {
@@ -21,6 +21,16 @@ export function renderConversations() {
   const list = document.getElementById("conversationList");
   if (!list) return;
   list.innerHTML = "";
+
+  if (state.conversations.length === 0) {
+    list.innerHTML = `
+      <div class="px-4 py-8 text-center">
+        <span class="material-symbols-outlined text-slate-600 text-3xl mb-2 block">forum</span>
+        <p class="text-xs text-slate-500 italic">No conversations yet</p>
+      </div>`;
+    return;
+  }
+
   state.conversations.forEach((c) => {
     const div = document.createElement("div");
     div.className = `conversation-item flex items-center justify-between px-3 py-2 text-sm rounded-r-lg cursor-pointer transition-all group ${
@@ -30,14 +40,22 @@ export function renderConversations() {
     }`;
     div.innerHTML = `
       <span class="truncate pr-2 pointer-events-none">${escapeHtml(c.title || "New Chat")}</span>
-      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button class="export-btn p-1 text-outline hover:text-secondary rounded" title="Export">📥</button>
-        <button class="delete-btn p-1 text-outline hover:text-error rounded" title="Delete">✕</button>
+      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        <button class="export-btn p-1 text-outline hover:text-secondary rounded flex items-center"
+          title="Export conversation" aria-label="Export conversation">
+          <span class="material-symbols-outlined text-base">download</span>
+        </button>
+        <button class="delete-btn p-1 text-outline hover:text-error rounded flex items-center"
+          title="Delete conversation" aria-label="Delete conversation">
+          <span class="material-symbols-outlined text-base">delete</span>
+        </button>
       </div>`;
     div.addEventListener("click", () => loadConversation(c.id));
     div.querySelector(".delete-btn").addEventListener("click", (e) => {
       e.stopPropagation();
-      deleteConversation(c.id);
+      if (confirm(`Delete "${c.title || "New Chat"}"?`)) {
+        deleteConversation(c.id);
+      }
     });
     div.querySelector(".export-btn").addEventListener("click", (e) => {
       e.stopPropagation();
@@ -65,6 +83,7 @@ export async function loadConversation(id) {
 export async function deleteConversation(id) {
   try {
     await fetch(`${API}/api/conversations/${id}`, { method: "DELETE" });
+    showToast("Conversation deleted", "success");
     if (state.currentConvId === id) {
       state.currentConvId = null;
       state.messages = [];

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.9.1",
-  "build": 262,
+  "build": 273,
   "codename": "Phase 9 \u2014 Intelligence",
-  "last_built": "2026-04-09T13:27:40.041393+00:00"
+  "last_built": "2026-06-09T03:04:19.465133+00:00"
 }


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the conversation list in the sidebar:
1. **Professional Iconography**: Swapped generic emojis (📥, ✕) for Material Symbols (`download`, `delete`) to align with the rest of the application's professional aesthetic.
2. **Enhanced Accessibility**: Added `aria-label` and `title` attributes to icon-only buttons, ensuring screen reader users understand the button actions.
3. **Keyboard Usability**: Added `group-focus-within:opacity-100` so that action buttons are visible and usable when navigating via keyboard, resolving a common "hover-only" accessibility trap.
4. **Safety & Feedback**: Introduced a native `confirm()` dialog for the destructive "Delete" action to prevent accidental loss of data, and added a success toast notification upon deletion.
5. **Helpful Empty State**: Implemented a clear empty state message ("No conversations yet") with a supporting icon to guide new users.

Verified with Playwright screenshots and existing test suites.

---
*PR created automatically by Jules for task [3995000287011464184](https://jules.google.com/task/3995000287011464184) started by @SamDeiter*