### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix RBAC prefix bypass and reinforce path jailing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-24 - RBAC Prefix Bypass via `str.startswith()`
+**Vulnerability:** Role-Based Access Control (RBAC) implementations often use `path.startswith(allowed_prefix)` to check permissions. This is vulnerable to prefix bypasses where a user with access to `/api/conversations` can access `/api/conversations_secrets` because the latter shares the same string prefix.
+**Learning:** `str.startswith()` is boundary-agnostic. For URI or file paths, a match must either be exact or followed by a path separator.
+**Prevention:** Use boundary-aware checks: `path == allowed_prefix or path.startswith(allowed_prefix.rstrip("/") + "/")`. For filesystem paths, use `Path.is_relative_to()`.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -488,7 +488,17 @@ class PromptGuard:
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
                         resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        # Boundary-aware jail check:
+                        # Ensures resolved path is either the job_dir itself or a child.
+                        # safe_resolve usually does this, but we reinforce it here correctly.
+                        try:
+                            # Path.is_relative_to (Python 3.9+) is the robust way to check boundaries.
+                            is_inside = resolved.resolve().is_relative_to(job_dir.resolve())
+                        except (ValueError, AttributeError):
+                            # Fallback if is_relative_to fails or is missing (though Python 3.12 has it)
+                            is_inside = False
+
+                        if not is_inside:
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,15 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Boundary-aware prefix check:
+        # 1. Exact match: /api/conversations == /api/conversations
+        # 2. Child path: /api/conversations/123 starts with /api/conversations/
+        # This prevents /api/conversations_secrets from matching /api/conversations.
+        is_path_match = (
+            path == allowed_prefix or
+            path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_path_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/tests/test_prompt_guard_security.py
+++ b/tests/test_prompt_guard_security.py
@@ -1,0 +1,61 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from backend.security.prompt_guard import PromptGuard
+
+def test_prompt_guard_path_jailing_bypass():
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/app/workspace")
+
+    call = {
+        "name": "read_file",
+        "args": {"path": "/app/workspace_evil/secret.txt"}
+    }
+
+    with patch("backend.security.prompt_guard.safe_resolve") as mock_resolve:
+        # safe_resolve returns the malicious path
+        mock_resolve.return_value = Path("/app/workspace_evil/secret.txt")
+
+        # We need to patch resolve() on Path to return self to avoid real filesystem access
+        # The issue with mock.patch.object(Path, 'resolve') is that it affects all Path instances
+        # and might break internal Path behavior if not careful.
+        with patch("pathlib.Path.resolve", autospec=True) as mock_res:
+            mock_res.side_effect = lambda self: self
+            result = guard.validate_tool_call(call, ["read_file"], job_dir)
+
+            assert result.valid is False
+            assert any("escapes job directory" in issue for issue in result.issues)
+
+def test_prompt_guard_path_jailing_valid():
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/app/workspace")
+
+    call = {
+        "name": "read_file",
+        "args": {"path": "safe.txt"}
+    }
+
+    with patch("backend.security.prompt_guard.safe_resolve") as mock_resolve:
+        mock_resolve.return_value = Path("/app/workspace/safe.txt")
+
+        with patch("pathlib.Path.resolve", autospec=True) as mock_res:
+            mock_res.side_effect = lambda self: self
+            result = guard.validate_tool_call(call, ["read_file"], job_dir)
+            assert result.valid is True
+
+def test_prompt_guard_path_jailing_exact():
+    guard = PromptGuard(level="strict")
+    job_dir = Path("/app/workspace")
+
+    call = {
+        "name": "read_file",
+        "args": {"path": "."}
+    }
+
+    with patch("backend.security.prompt_guard.safe_resolve") as mock_resolve:
+        mock_resolve.return_value = Path("/app/workspace")
+
+        with patch("pathlib.Path.resolve", autospec=True) as mock_res:
+            mock_res.side_effect = lambda self: self
+            result = guard.validate_tool_call(call, ["read_file"], job_dir)
+            assert result.valid is True

--- a/tests/test_rbac_security.py
+++ b/tests/test_rbac_security.py
@@ -1,0 +1,21 @@
+import pytest
+from backend.security.rbac import _is_allowed
+
+def test_rbac_prefix_bypass():
+    # 'operator' role has permission for '/api/conversations' (POST, PUT, DELETE)
+    # It should NOT have permission for '/api/conversations_secrets'
+    # Note: operator has ("GET", "/api/") so GET would be allowed anyway.
+    assert _is_allowed("operator", "DELETE", "/api/conversations") is True
+
+    # This was the vulnerability: '/api/conversations_secrets' starts with '/api/conversations'
+    # but it is a DIFFERENT logical resource/endpoint.
+    assert _is_allowed("operator", "DELETE", "/api/conversations_secrets") is False
+
+def test_rbac_exact_match():
+    assert _is_allowed("operator", "GET", "/api/conversations") is True
+    assert _is_allowed("operator", "POST", "/api/chat") is True
+
+def test_rbac_child_path():
+    # '/api/conversations/123' is a child of '/api/conversations' and should be allowed
+    assert _is_allowed("operator", "GET", "/api/conversations/123") is True
+    assert _is_allowed("operator", "DELETE", "/api/conversations/123") is True


### PR DESCRIPTION
This PR fixes a critical security vulnerability where `str.startswith()` was used for path-based authorization and jailing without enforcing boundaries. This allowed unauthorized access to resources that shared a string prefix with allowed resources.

Changes:
1.  **RBAC Fix**: In `backend/security/rbac.py`, updated `_is_allowed` to ensure that a match is either exact or followed by a `/` separator.
2.  **Path Jailing Reinforcement**: In `backend/security/prompt_guard.py`, replaced a vulnerable string prefix check with `Path.is_relative_to()` for more robust child-path verification.
3.  **Security Tests**: Added two new test suites to verify these fixes and prevent regressions:
    *   `tests/test_rbac_security.py`: Verifies RBAC boundary enforcement.
    *   `tests/test_prompt_guard_security.py`: Verifies path jailing boundary enforcement.
4.  **Security Journal**: Documented the vulnerability and learning in `.jules/sentinel.md`.

Verified with 109 passing tests.

---
*PR created automatically by Jules for task [1107842302952729624](https://jules.google.com/task/1107842302952729624) started by @SamDeiter*