### PR TITLE
🎨 Palette: Improve conversation sidebar accessibility and visuals

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -3,3 +3,7 @@
 ## 2025-05-15 - [Enhanced Voice Feedback & Typing Visibility]
 **Learning:** Interactive elements like voice input and typing indicators are crucial for user experience but often lack clear visual feedback or accessibility considerations. A pulsing animation for the active microphone provides immediate, non-intrusive feedback, while dynamic `aria-label` updates ensure accessibility for screen readers. Consistent styling for typing indicators across the application prevents fragmented user experiences.
 **Action:** Always ensure interactive states have distinct visual cues and corresponding accessibility attributes to maintain a delightful and inclusive interface.
+
+## 2025-05-22 - [Sidebar Action Accessibility & Discoverability]
+**Learning:** Hidden action buttons in list items (like 'Delete' or 'Export') are often inaccessible to keyboard users and screen readers if they only appear on hover. Using `group-focus-within` ensures they become visible when any element in the item is focused. Replacing emojis with semantic Material Symbols and adding explicit ARIA labels improves professional aesthetic and screen reader clarity.
+**Action:** Always use `group-focus-within` for hover-triggered actions and prefer semantic icons with ARIA labels over emojis.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -330,10 +330,16 @@
                                         <span class="material-symbols-outlined text-lg">volume_up</span>
                                     </button>
                                 </div>
-                                <button id="sendBtn" aria-label="Send Message" title="Send this message"
-                                    class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
-                                    <span class="material-symbols-outlined text-lg">arrow_upward</span>
-                                </button>
+                                <div class="flex items-center gap-2">
+                                    <button id="stopBtn" aria-label="Stop Generation" title="Stop generation"
+                                        class="p-2 rounded-lg text-slate-500 hover:text-error hover:bg-slate-800/50 transition-all" style="display: none;">
+                                        <span class="material-symbols-outlined text-lg">stop_circle</span>
+                                    </button>
+                                    <button id="sendBtn" aria-label="Send Message" title="Send this message"
+                                        class="primary-gradient p-2 rounded-lg text-on-primary transition-all">
+                                        <span class="material-symbols-outlined text-lg">arrow_upward</span>
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/frontend/modules/conversations.js
+++ b/frontend/modules/conversations.js
@@ -21,6 +21,15 @@ export function renderConversations() {
   const list = document.getElementById("conversationList");
   if (!list) return;
   list.innerHTML = "";
+
+  if (state.conversations.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "text-[11px] text-slate-600 italic px-4 py-8 text-center";
+    empty.textContent = "No conversations yet";
+    list.appendChild(empty);
+    return;
+  }
+
   state.conversations.forEach((c) => {
     const div = document.createElement("div");
     div.className = `conversation-item flex items-center justify-between px-3 py-2 text-sm rounded-r-lg cursor-pointer transition-all group ${
@@ -30,9 +39,13 @@ export function renderConversations() {
     }`;
     div.innerHTML = `
       <span class="truncate pr-2 pointer-events-none">${escapeHtml(c.title || "New Chat")}</span>
-      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button class="export-btn p-1 text-outline hover:text-secondary rounded" title="Export">📥</button>
-        <button class="delete-btn p-1 text-outline hover:text-error rounded" title="Delete">✕</button>
+      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        <button class="export-btn p-1 text-outline hover:text-secondary rounded flex items-center" title="Export" aria-label="Export conversation">
+          <span class="material-symbols-outlined text-[16px]">download</span>
+        </button>
+        <button class="delete-btn p-1 text-outline hover:text-error rounded flex items-center" title="Delete" aria-label="Delete conversation">
+          <span class="material-symbols-outlined text-[16px]">delete</span>
+        </button>
       </div>`;
     div.addEventListener("click", () => loadConversation(c.id));
     div.querySelector(".delete-btn").addEventListener("click", (e) => {
@@ -63,6 +76,7 @@ export async function loadConversation(id) {
 }
 
 export async function deleteConversation(id) {
+  if (!confirm("Are you sure you want to delete this conversation?")) return;
   try {
     await fetch(`${API}/api/conversations/${id}`, { method: "DELETE" });
     if (state.currentConvId === id) {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.9.1",
-  "build": 262,
+  "build": 271,
   "codename": "Phase 9 \u2014 Intelligence",
-  "last_built": "2026-04-09T13:27:40.041393+00:00"
+  "last_built": "2026-06-10T02:10:29.240403+00:00"
 }


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements to the LocalMind frontend, specifically targeting the conversation management sidebar and chat interactions.

### 💡 What
- **Sidebar Empty State:** Displays a helpful message when no conversations are present.
- **Keyboard Accessibility:** Uses Tailwind's `group-focus-within` to ensure action buttons (Export, Delete) are visible and usable when the list item receives keyboard focus.
- **Visual Consistency:** Replaces emojis with Material Symbols (`download`, `delete`) to align with the application's design system.
- **Safety:** Adds a standard browser `confirm()` dialog before deleting a conversation.
- **Stop Button:** Restores the `#stopBtn` UI placeholder in the chat input area, allowing for future integration of streaming interruption logic.

### 🎯 Why
- Users with empty sidebars previously saw a confusing void; the empty state provides context.
- Keyboard-only users were previously unable to discover or trigger conversation actions.
- Semantic icons and ARIA labels improve clarity for screen readers and maintain professional polish.
- The confirmation prompt protects users from irreversible accidental deletions.

### ♿ Accessibility
- Added `aria-label` to all icon-only buttons.
- Improved keyboard discoverability for sidebar actions.
- Maintained high contrast and focus-visible states.

---
*PR created automatically by Jules for task [7458451413853645574](https://jules.google.com/task/7458451413853645574) started by @SamDeiter*