### PR TITLE
🛡️ Sentinel: Fix path and route boundary bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2025-05-14 - API Route & Path Jailing Boundary Bypass
+**Vulnerability:** Using `path.startswith("/api/chat")` for authorization or path jailing allows access to siblings like `/api/chat_secrets` or `/app/job_1_extra`.
+**Learning:** String prefix matching is not a safe proxy for path or route containment. It fails when a resource name is a prefix of another sensitive resource.
+**Prevention:** Use boundary-aware checks: `path == prefix or path.startswith(prefix.rstrip("/") + "/")`. For filesystem paths, use `Path.relative_to()` or `safe_resolve` with correct argument ordering.

--- a/backend/security/paths.py
+++ b/backend/security/paths.py
@@ -144,6 +144,11 @@ def safe_resolve(base_dir: Path | str, user_path: str | Path) -> Path:
     base_dir = Path(base_dir)
     user_path_str = str(user_path)
 
+    # Security: Normalize backslashes to forward slashes even on POSIX to
+    # prevent bypasses in jail checks if the OS doesn't handle them as separators.
+    if os.name != "nt":
+        user_path_str = user_path_str.replace("\\", "/")
+
     # --- Null-byte check (would truncate C strings silently) ---------------
     if "\x00" in user_path_str:
         logger.warning("Null byte detected in path: %r", user_path_str)

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -29,7 +29,7 @@ logger = logging.getLogger("localmind.security.prompt_guard")
 try:
     from backend.security.paths import safe_resolve  # type: ignore
 except ImportError:  # paths module not yet available (circular / missing)
-    def safe_resolve(path: str | Path, base: Path) -> Path:  # type: ignore[misc]
+    def safe_resolve(base: Path, path: str | Path) -> Path:  # type: ignore[misc]
         """Fallback: resolve without jail check."""
         return Path(path).resolve()
 
@@ -487,8 +487,15 @@ class PromptGuard:
                 lower_name = arg_name.lower()
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
-                        resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        # Security: use safe_resolve with correct (base, path) order.
+                        # safe_resolve already performs boundary-aware jail checks.
+                        resolved = safe_resolve(job_dir, arg_value)
+
+                        # Extra safety: boundary-aware check using Path.relative_to
+                        # (prevents prefix bypasses like /app/job_1_extra vs /app/job_1)
+                        try:
+                            resolved.relative_to(job_dir.resolve())
+                        except ValueError:
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,12 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Security: Use boundary-aware prefix check to avoid partial string matches
+        # (e.g. /api/chat matching /api/chat_secrets).
+        is_path_match = (
+            path == allowed_prefix or path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_path_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/backend/server.py
+++ b/backend/server.py
@@ -291,7 +291,12 @@ async def auth_middleware(request: Request, call_next):
     path = request.url.path
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    # Security: Use boundary-aware prefix check to avoid partial string matches
+    is_skip_prefix = any(
+        path == p or path.startswith(p.rstrip("/") + "/")
+        for p in _AUTH_SKIP_PREFIXES
+    )
+    if path in _AUTH_SKIP_EXACT or is_skip_prefix:
         return await call_next(request)
 
     # Only enforce auth on /api/ routes


### PR DESCRIPTION
This PR addresses a critical class of vulnerabilities where string-based prefix matching was used for security boundaries (authorization and path jailing). 

Specifically:
1. **RBAC & Auth Middleware**: Changed `.startswith()` checks to boundary-aware checks that ensure a match only occurs if the path is identical to the prefix or followed by a directory separator. This prevents an 'operator' from accessing `/api/chat_secrets` if they only have permission for `/api/chat`.
2. **Path Jailing in PromptGuard**: Fixed an issue where `safe_resolve` was called with inverted arguments and added a `Path.relative_to` check to ensure resolved paths are strictly within the designated job directory.
3. **Backslash Normalization**: `safe_resolve` now normalizes backslashes to forward slashes on POSIX systems. This is a defense-in-depth measure against traversal attempts that use backslashes which some libraries might interpret as separators even on Linux.

Verification:
- Created a dedicated test suite (`verify_security_fixes.py`) to confirm boundary rejection.
- Ran existing enterprise security tests (`tests/test_enterprise_security.py`, etc.) and confirmed 242/243 passed (fixed one pre-existing failure related to backslash handling on POSIX).
- Verified that all relevant components still function as expected.

---
*PR created automatically by Jules for task [2096185203563842607](https://jules.google.com/task/2096185203563842607) started by @SamDeiter*