### PR TITLE
🛡️ Sentinel: Fix prefix-matching bypass vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Simple prefix checks like `command.startswith("rm")` are easily bypassed by chaining commands with shell operators such as `;`, `&&`, `||`, or newlines (e.g., `ls ; rm -rf /`).
 **Learning:** `startswith()` only checks the beginning of the entire input string. In a shell context, one input string can contain multiple independent commands.
 **Prevention:** Split the input command string by shell operators (`[;&|\n]`) and validate each resulting segment individually. Use regex with word boundaries (`\b`) to prevent false positives and bypasses (e.g., `army` vs `rm`).
+
+## 2026-06-12 - Prefix-matching bypass in Path/URL validation
+**Vulnerability:** Using `path.startswith("/api/chat")` allows a bypass for `/api/chat_admin` because it shares the same string prefix. This can lead to unauthorized access to sensitive endpoints or directory traversal.
+**Learning:** Simple string prefix checks do not respect path or URL segment boundaries (like `/`).
+**Prevention:** Use boundary-aware matching: `path == prefix or path.startswith(prefix.rstrip("/") + "/")`. This ensures the match is either exact or followed by a directory separator.

--- a/backend/security/prompt_guard.py
+++ b/backend/security/prompt_guard.py
@@ -488,7 +488,14 @@ class PromptGuard:
                 if any(kw in lower_name for kw in ("path", "file", "dir", "folder", "dest", "src")):
                     try:
                         resolved = safe_resolve(arg_value, job_dir)
-                        if not str(resolved).startswith(str(job_dir.resolve())):
+                        resolved_str = str(resolved)
+                        job_dir_str = str(job_dir.resolve())
+                        # Boundary-aware jail check to prevent /tmp/job1_secret matching /tmp/job1
+                        is_inside = (
+                            resolved_str == job_dir_str
+                            or resolved_str.startswith(job_dir_str.rstrip("/") + "/")
+                        )
+                        if not is_inside:
                             issues.append(
                                 f"Arg '{arg_name}' escapes job directory: {resolved}"
                             )

--- a/backend/security/rbac.py
+++ b/backend/security/rbac.py
@@ -76,7 +76,12 @@ def _is_allowed(role: str, method: str, path: str) -> bool:
     permissions = ROLE_PERMISSIONS.get(role, [])
     method_upper = method.upper()
     for allowed_method, allowed_prefix in permissions:
-        if path.startswith(allowed_prefix):
+        # Boundary-aware prefix check to prevent /api/chat_admin from matching /api/chat
+        is_match = (
+            path == allowed_prefix
+            or path.startswith(allowed_prefix.rstrip("/") + "/")
+        )
+        if is_match:
             if allowed_method == "*" or allowed_method == method_upper:
                 return True
     return False

--- a/backend/server.py
+++ b/backend/server.py
@@ -291,7 +291,10 @@ async def auth_middleware(request: Request, call_next):
     path = request.url.path
 
     # Skip auth for non-API routes
-    if path in _AUTH_SKIP_EXACT or any(path.startswith(p) for p in _AUTH_SKIP_PREFIXES):
+    if path in _AUTH_SKIP_EXACT or any(
+        path == p or path.startswith(p.rstrip("/") + "/")
+        for p in _AUTH_SKIP_PREFIXES
+    ):
         return await call_next(request)
 
     # Only enforce auth on /api/ routes


### PR DESCRIPTION
🛡️ Sentinel: Fix prefix-matching bypass vulnerabilities in RBAC and Path validation

Identified and fixed a security vulnerability pattern where `startswith()` was used for path and URL prefix matching without segment-boundary awareness.

Vulnerabilities addressed:
1. RBAC: Prevented unauthorized access to endpoints like `/api/chat_admin` when only `/api/chat` was permitted.
2. Auth Middleware: Prevented authentication bypass for paths like `/health_secret` by exploiting `_AUTH_SKIP_PREFIXES`.
3. PromptGuard: Fixed a path jailing bypass where `/tmp/job1_secret` would match `/tmp/job1`.

Fix: Implemented boundary-aware matching logic `path == prefix or path.startswith(prefix.rstrip("/") + "/")` across the backend.

Verified with:
- New reproduction test suite (tests/reproduce_vulnerability.py).
- Existing test suite (tests/test_auth_rbac.py, tests/test_security.py).

---
*PR created automatically by Jules for task [17836368230593705101](https://jules.google.com/task/17836368230593705101) started by @SamDeiter*